### PR TITLE
[migrations] Fixed django 2.0/1.11 conflict in migration and added checks to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
 # command to run tests, e.g. python setup.py test
 script:
   - coverage run --source=openwisp_users runtests.py
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then ./tests/manage.py makemigrations --dry-run | grep "No changes detected"; fi
 
 after_success:
   coveralls

--- a/openwisp_users/models.py
+++ b/openwisp_users/models.py
@@ -39,6 +39,7 @@ class User(AbstractUser):
     OpenWISP User model
     """
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    last_name = models.CharField(_('last name'), max_length=30, blank=True)
     bio = models.TextField(_('bio'), blank=True)
     url = models.URLField(_('URL'), blank=True)
     company = models.CharField(_('company'), max_length=30, blank=True)


### PR DESCRIPTION
This file not being present is breaking the Travis checks on django>=2.0. Probably generated on adding compatibility to django>=2.0