### PR TITLE
[ci] Fixing Travis Build

### DIFF
--- a/runflake8
+++ b/runflake8
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 flake8 --max-line-length=110 \
-       --exclude=migrations,./tests/*settings*.py || exit 1
+       --exclude=migrations,./tests/*settings*.py,./setup.py  || exit 1


### PR DESCRIPTION
Fixed: Travis builds fail due to flake8 error on setup.py.