### PR TITLE
[requirements] Checking version of openwisp-utils

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,4 @@ coverage
 coveralls
 isort
 flake8
-openwisp-utils
+openwisp-utils>=0.2.1


### PR DESCRIPTION
Added `>=0.2.1` to make sure that version of `openwisp-utils` is at least `0.2.1`