### PR TITLE
[tests] Added TestBasicUsersIntegration

### DIFF
--- a/openwisp_users/tests/utils.py
+++ b/openwisp_users/tests/utils.py
@@ -37,8 +37,8 @@ class TestOrganizationMixin(object):
                                             password='tester',
                                             email='operator@test.com',
                                             is_staff=True)
-        operator.user_permissions.add(
-            *Permission.objects.filter(codename__endswith='user'))
+        user_permissions = Permission.objects.filter(codename__endswith='user')
+        operator.user_permissions.add(*user_permissions)
         return operator
 
     def _get_org(self, org_name='test org'):


### PR DESCRIPTION
Added `TestBasicUsersIntegration`, which we can use in `openwisp-radius` to perform a basic integration.

Related to https://github.com/openwisp/openwisp-radius/issues/1