### PR TITLE
added redirect_view to urls, to directly land on '/admin' page.

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,15 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.views.generic import RedirectView
+from django.urls import reverse_lazy
+
+redirect_view = RedirectView.as_view(url=reverse_lazy('admin:index'))
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^accounts/', include('openwisp_users.accounts.urls')),
+    url(r'^$', redirect_view, name='index')
 ]
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
I think this is a small enhancement, as we would be redirected directly to, `admin` page, after entering `runserver` on console.