### PR TITLE
[admin] Existing OrganizationUser in inline should always show the or…

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ isort
 flake8
 openwisp-utils[qa]>=0.2.1
 mock>=2.0.0
+packaging


### PR DESCRIPTION
…g related to that user #44

Solved the problem by removing the is_admin=True from the operator_org
queryset.
Created a test case in which an operator is created with is_staff set to
true and user permissions added to him. 3 organizations were created:
org1, org2 and operator was made member of these orgs and admin of
org1. the change page of the operator was visited and checked if
operator could see all the orgs which he is a member of or not.

Fixes #44