### PR TITLE
[models] Add possibility to validate inverse relations #4

### DIFF
--- a/openwisp_users/mixins.py
+++ b/openwisp_users/mixins.py
@@ -27,6 +27,18 @@ class ValidateOrgMixin(object):
                                      related_object_label=rel._meta.verbose_name)
             raise ValidationError({field_error: message})
 
+    def _validate_org_reverse_relation(self, rel, field_error='organization'):
+        try:
+            old_org = self.__class__.objects.get(pk=self.pk).organization
+            if old_org != self.organization:
+                count = eval('self.__class__.objects.get(pk=self.pk).{0}_set.count()'.format(rel))
+                if count > 0:
+                    message = _('organization cannot be changed because {0}'
+                                ' objects as still related to it'.format(count))
+                    raise ValidationError({field_error: message})
+        except self.__class__.DoesNotExist:
+            return
+
 
 class OrgMixin(ValidateOrgMixin, models.Model):
     """

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -8,6 +8,9 @@ from openwisp_utils.base import TimeStampedEditableModel
 class Template(ShareableOrgMixin):
     name = models.CharField(max_length=16)
 
+    def clean(self):
+        self._validate_org_reverse_relation('config')
+
 
 class Config(OrgMixin):
     name = models.CharField(max_length=16)

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -40,6 +40,16 @@ class TestIntegration(TestOrganizationMixin, TestCase):
         with self.assertRaises(ValidationError):
             c.full_clean()
 
+    def test_validate_reverse_org_relation(self):
+        org1 = self._create_org(name='org1')
+        org2 = self._create_org(name='org2')
+        t = Template.objects.create(name='test-t', organization=org1)
+        Config.objects.create(name='test-c1', template=t, organization_id=str(org1.pk))
+        with self.assertRaises(ValidationError):
+            t.organization = org2
+            t.full_clean()
+            t.save()
+
     def test_resolve_account_URLs(self):
         resolver = resolve('/accounts/login/')
         self.assertEqual(resolver.view_name, 'account_login')


### PR DESCRIPTION
Added a reverse validation method which ensures that before the
organization of an object is changed, no object is related to it, else a
validation error is raised.
The method receives as arguments the models which are related to the
current entity and count for that the possible relations to this entity
with this particular organization.

Fixes #4