### PR TITLE
[models] Email: allow NULL but set UNIQUE constraint #28

### DIFF
--- a/openwisp_users/migrations/0007_unique_email.py
+++ b/openwisp_users/migrations/0007_unique_email.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+def set_blank_emails_to_none(apps, schema_editor):
+    User = apps.get_model('openwisp_users', 'User')
+    # if there is any user with blank email address
+    # set its email address to None, otherwise the
+    # unique constraint will be triggered by the empty string
+    for user in User.objects.filter(email=''):
+        user.email = None
+        user.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('openwisp_users', '0006_id_email_index_together'),
+    ]
+
+    operations = [
+        # allow NULL
+        migrations.AlterField(
+            model_name='user',
+            name='email',
+            field=models.EmailField(blank=True, max_length=254, null=True, verbose_name='email address'),
+        ),
+        # data migration to change empty strings to NULL
+        migrations.RunPython(set_blank_emails_to_none,
+                             reverse_code=migrations.RunPython.noop),
+        # add unique constraint
+        migrations.AlterField(
+            model_name='user',
+            name='email',
+            field=models.EmailField(blank=True, max_length=254, null=True, unique=True, verbose_name='email address'),
+        ),
+    ]

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -230,7 +230,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestCase):
         params.update(self.add_user_inline_params)
         self.client.post(reverse('admin:openwisp_users_user_add'), params)
         res = self.client.post(reverse('admin:openwisp_users_user_add'), params)
-        self.assertContains(res, '<li>A user with this email already exists.</li>')
+        self.assertContains(res, '<li>User with this Email address already exists.</li>')
 
     def test_edit_user_email_exists(self):
         admin = self._create_admin()
@@ -256,7 +256,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestCase):
         })
         res = self.client.post(reverse('admin:openwisp_users_user_change', args=[user.pk]), params,
                                follow=True)
-        self.assertContains(res, '<li>A user with this email already exists.</li>')
+        self.assertContains(res, '<li>User with this Email address already exists.</li>')
 
     def test_admin_add_user_by_superuser(self):
         admin = self._create_admin()

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -41,6 +41,7 @@ class TestUsers(TestOrganizationMixin, TestCase):
         u = self.user_model(**options)
         u.full_clean()
         u.save()
+        self.assertIsNone(u.email)
 
     def test_organizations_pk(self):
         user = self._create_user(username='organizations_pk')
@@ -59,3 +60,19 @@ class TestUsers(TestOrganizationMixin, TestCase):
     def test_organization_repr(self):
         org = self._create_org(name='org1', is_active=False)
         self.assertIn('disabled', str(org))
+
+    def test_create_users_without_email(self):
+        options = {
+            'username': 'testuser',
+            'password': 'test1',
+        }
+        u = self.user_model(**options)
+        u.full_clean()
+        u.save()
+        self.assertIsNone(u.email)
+        options['username'] = 'testuser2'
+        u = self.user_model(**options)
+        u.full_clean()
+        u.save()
+        self.assertIsNone(u.email)
+        self.assertEqual(User.objects.filter(email=None).count(), 2)


### PR DESCRIPTION
NULL does not trigger the UNIQUE constraint so we
can allow the system to have users without email
(for users automatically generated by the radius module)

Related to #28.