### PR TITLE
[admin] Server Error (500). openwisp#72

### DIFF
--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -1,3 +1,4 @@
+import logging
 from copy import deepcopy
 
 from allauth.account.models import EmailAddress
@@ -21,6 +22,8 @@ from .base import BaseAdmin
 from .models import (Group, Organization, OrganizationOwner, OrganizationUser,
                      User)
 from .multitenancy import MultitenantAdminMixin
+
+logger = logging.getLogger(__name__)
 
 
 class EmailAddressInline(admin.StackedInline):
@@ -217,11 +220,19 @@ class UserAdmin(MultitenantAdminMixin, BaseUserAdmin, BaseAdmin):
         """
         super(UserAdmin, self).save_model(request, obj, form, change)
         if obj.email:
-            EmailAddress.objects.add_email(request,
-                                           user=obj,
-                                           email=obj.email,
-                                           confirm=True,
-                                           signup=True)
+            try:
+                EmailAddress.objects.add_email(request,
+                                               user=obj,
+                                               email=obj.email,
+                                               confirm=True,
+                                               signup=True)
+            except Exception as e:
+                logger.exception(
+                    'Got exception {} while sending '
+                    'verification email to user {}, email {}'.format(
+                        type(e), obj.username, obj.email
+                    )
+                )
 
 
 base_fields = list(UserAdmin.fieldsets[1][1]['fields'])

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ coveralls
 isort
 flake8
 openwisp-utils[qa]>=0.2.1
+mock>=2.0.0


### PR DESCRIPTION
log the exception sendmail raised during
user creation with invalid email so that
users are created even with invalid email.
Added a mock test to mimic the exception
raised during user creation.
Added mock to requirements-test.txt

Fixes openwisp#72