### PR TITLE
[Travis] Fixed Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: false
+os: linux
 cache: pip
 
 python:


### PR DESCRIPTION
[warn] on root: deprecated key: "sudo" (The key `sudo` has no effect anymore.)

[info] on root: the key matrix is an alias for jobs, using jobs