### PR TITLE
[admin] Superuser can't delete a regular user #110

### DIFF
--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -362,7 +362,9 @@ class OrganizationUserAdmin(
         operators should not delete organization users of organizations
         where they are not admins
         """
-        if obj and not request.user.is_superuser:
+        if request.user.is_superuser:
+            return True
+        if obj:
             operator_org = OrganizationUser.objects.get(
                 organization=obj.organization, user=request.user
             )

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -588,6 +588,24 @@ class TestUsersAdmin(TestOrganizationMixin, TestCase):
         self.assertTrue(user.is_active)
         self.assertEqual(response.status_code, 200)
 
+    def test_superuser_delete_operator(self):
+        user = self._create_operator()
+        org = self._create_org()
+        org_user = self._create_org_user(user=user, organization=org, is_admin=True)
+        post_data = {
+            '_selected_action': [user.pk],
+            'action': 'delete_selected',
+            'post': 'yes',
+        }
+        self.client.force_login(self._get_admin())
+        path = reverse('admin:openwisp_users_user_changelist')
+        r = self.client.post(path, post_data, follow=True)
+        user_qs = User.objects.filter(pk=user.pk)
+        org_user_qs = OrganizationUser.objects.filter(pk=org_user.pk)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(user_qs.count(), 0)
+        self.assertEqual(org_user_qs.count(), 0)
+
     @patch('sys.stdout', devnull)
     @patch('sys.stderr', devnull)
     def test_admin_add_user_with_invalid_email(self):


### PR DESCRIPTION
It is but normal that a superuser should able to
delete any object including organizationuser.
Thus, I fixed the issue by updating the
has_delete_permision of organizationuser to
return True for superusers

Fixes #110