### PR TITLE
[bug] empty phone number triggers unique validation error #141

### DIFF
--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -119,6 +119,8 @@ class AbstractUser(BaseUser):
     def clean(self):
         if self.email == '':
             self.email = None
+        if self.phone_number == '':
+            self.phone_number = None
 
 
 class BaseGroup(object):

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -166,3 +166,24 @@ class TestUsers(TestOrganizationMixin, TestCase):
         u.save()
         self.assertIsNone(u.email)
         self.assertEqual(User.objects.filter(email=None).count(), 2)
+
+    def test_add_users_with_empty_phone_numbers(self):
+        user1 = self.user_model(
+            username='user1',
+            email='email1@email.com',
+            password='user1',
+            phone_number='',
+        )
+        user2 = self.user_model(
+            username='user2',
+            email='email2@email.com',
+            password='user2',
+            phone_number='',
+        )
+        user1.full_clean()
+        user2.full_clean()
+        user1.save()
+        user2.save()
+        self.assertIsNone(user1.phone_number)
+        self.assertIsNone(user2.phone_number)
+        self.assertEqual(self.user_model.objects.filter(phone_number=None).count(), 2)


### PR DESCRIPTION
Fixed the issue by cleaning phone numbers to ensure that empty
phone numbers are set to None.

Fixes #141