### PR TITLE
[fix] Fixed apps logger

### DIFF
--- a/openwisp_users/apps.py
+++ b/openwisp_users/apps.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.cache import cache
@@ -9,7 +11,8 @@ from openwisp_utils import settings as utils_settings
 from swapper import get_model_name, load_model
 
 from . import settings as app_settings
-from .utils import logger
+
+logger = logging.getLogger(__name__)
 
 
 class OpenwispUsersConfig(AppConfig):

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 from django.urls import reverse
 from swapper import load_model
 
-from ..utils import logger
+from ..apps import logger as apps_logger
 from .utils import (
     TestMultitenantAdminMixin,
     TestOrganizationMixin,
@@ -732,7 +732,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
     @patch.object(
         OrganizationOwner, 'full_clean', side_effect=ValidationError('invalid')
     )
-    @patch.object(logger, 'exception')
+    @patch.object(apps_logger, 'exception')
     def test_invalid_org_owner(self, mocked_owner, logger_exception):
         org = self._create_org(name='invalid')
         user = self._create_user(username='invalid', email='invalid@email.com')

--- a/openwisp_users/utils.py
+++ b/openwisp_users/utils.py
@@ -1,13 +1,9 @@
-import logging
-
 from django.conf import settings
 
 if 'reversion' in settings.INSTALLED_APPS:  # pragma: no cover
     from reversion.admin import VersionAdmin as BaseModelAdmin
 else:
     from django.contrib.admin import ModelAdmin as BaseModelAdmin
-
-logger = logging.getLogger(__name__)
 
 
 class BaseAdmin(BaseModelAdmin):


### PR DESCRIPTION
`from .utils import logger` was importing from a file
which imported concrete models, thing which breaks
the application startup when using it with other modules.