### PR TITLE
[fix] OrganizationOwner shouldn't be allowed to be is_admin=False #166

### DIFF
--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -224,6 +224,15 @@ class BaseOrganizationUser(models.Model):
     class Meta:
         abstract = True
 
+    def clean(self):
+        if self.user.is_owner(str(self.organization_id)) and not self.is_admin:
+            raise ValidationError(
+                _(
+                    f'{self.user.username} is the owner of the organization: '
+                    f'{self.organization}, and cannot be downgraded'
+                )
+            )
+
 
 class BaseOrganizationOwner(models.Model):
     """

--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -83,8 +83,12 @@ class AbstractUser(BaseUser):
         """ meant for internal usage only """
         if isinstance(obj, (uuid.UUID, str)):
             pk = obj
-        else:
+        elif isinstance(obj, BaseOrganization):
             pk = obj.pk
+        elif obj is None:
+            return None
+        else:
+            raise ValueError('expected UUID, str or Organization instance')
         return str(pk)
 
     def is_member(self, organization):
@@ -225,7 +229,7 @@ class BaseOrganizationUser(models.Model):
         abstract = True
 
     def clean(self):
-        if self.user.is_owner(str(self.organization_id)) and not self.is_admin:
+        if self.user.is_owner(self.organization_id) and not self.is_admin:
             raise ValidationError(
                 _(
                     f'{self.user.username} is the owner of the organization: '

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -286,9 +286,19 @@ class TestUsers(TestOrganizationMixin, TestCase):
     def test_user_get_pk(self):
         org = Organization.objects.first()
         pk = str(org.pk)
-        self.assertEqual(User._get_pk(org), pk)
-        self.assertEqual(User._get_pk(org.pk), pk)
-        self.assertEqual(User._get_pk(pk), pk)
+        with self.subTest('standard tests'):
+            self.assertEqual(User._get_pk(org), pk)
+            self.assertEqual(User._get_pk(org.pk), pk)
+            self.assertEqual(User._get_pk(pk), pk)
+        with self.subTest('None case'):
+            self.assertEqual(User._get_pk(None), None)
+        with self.subTest('ValueError if another type passed'):
+            with self.assertRaises(ValueError) as context_manager:
+                User._get_pk([])
+            self.assertEqual(
+                str(context_manager.exception),
+                'expected UUID, str or Organization instance',
+            )
 
     def test_orguser_is_admin_change(self):
         org = self._create_org(name='test-org')


### PR DESCRIPTION
Fixed issue by preventing org owners from been downgraded.

Fixes #166