### PR TITLE
[chores] Allow passing a string or uuid to the membership helpers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,10 +344,19 @@ many database queries.
     user.is_manager(org)
     user.is_owner(org)
 
+    # also valid (avoids query to retrieve Organization instance)
+    device = Device.objects.first()
+    user.is_member(device.organization_id)
+    user.is_manager(device.organization_id)
+    user.is_owner(device.organization_id)
+
 ``is_member(org)``
 ~~~~~~~~~~~~~~~~~~
 
 Returns ``True`` if the user is member of the ``Organization`` instance passed.
+Alternatively, ``UUID`` or ``str`` can be passed instead of an organization instance,
+which will be interpreted as the organization primary key; this second option is
+recommended when building the organization instance requires an extra query.
 
 This check shall be used when access needs to be granted to end-users who
 need to consume a service offered by an organization they're member of
@@ -358,6 +367,9 @@ need to consume a service offered by an organization they're member of
 
 Returns ``True`` if the user is member of the ``Organization`` instance
 and has the ``OrganizationUser.is_admin`` field set to ``True``.
+Alternatively, ``UUID`` or ``str`` can be passed instead of an organization instance,
+which will be interpreted as the organization primary key; this second option is
+recommended when building the organization instance requires an extra query.
 
 This check shall be used when access needs to be granted to the managers of
 an organization users who need to perform administrative tasks
@@ -369,6 +381,9 @@ an organization users who need to perform administrative tasks
 Returns ``True`` if the user is member of the ``Organization`` instance
 and is owner of the organization (checks the presence of an
 ``OrganizationOwner`` instance for the user).
+Alternatively, ``UUID`` or ``str`` can be passed instead of an organization instance,
+which will be interpreted as the organization primary key; this second option is
+recommended when building the organization instance requires an extra query.
 
 There can be only one owner for each organization.
 

--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -78,15 +78,24 @@ class AbstractUser(BaseUser):
         )
         return qs
 
+    @staticmethod
+    def _get_pk(obj):
+        """ meant for internal usage only """
+        if isinstance(obj, (uuid.UUID, str)):
+            pk = obj
+        else:
+            pk = obj.pk
+        return str(pk)
+
     def is_member(self, organization):
-        return str(organization.pk) in self.organizations_dict
+        return self._get_pk(organization) in self.organizations_dict
 
     def is_manager(self, organization):
-        org_dict = self.organizations_dict.get(str(organization.pk))
+        org_dict = self.organizations_dict.get(self._get_pk(organization))
         return org_dict is not None and (org_dict['is_admin'] or org_dict['is_owner'])
 
     def is_owner(self, organization):
-        org_dict = self.organizations_dict.get(str(organization.pk))
+        org_dict = self.organizations_dict.get(self._get_pk(organization))
         return org_dict is not None and org_dict['is_owner']
 
     @cached_property


### PR DESCRIPTION
Allow passing an UUID or str to the membership helpers, which will
be interpreted as organization primary key.
This is useful in those cases in which building the organization
instance requires generating an extra DB query: passing
obj.organization_id instead of obj.organization will result
in less queries being executed.