### PR TITLE
[change] Removed typographic error for backward compatibility for openwisp-users 0.5 #194

### DIFF
--- a/openwisp_users/settings.py
+++ b/openwisp_users/settings.py
@@ -1,18 +1,8 @@
 from django.conf import settings
 from openwisp_utils.utils import default_or_test
 
-ORGANIZATION_USER_ADMIN = (
-    # setting with typographic error for maintaining backward compatibility
-    # TODO: remove in openwisp-users 0.5
-    getattr(settings, 'OPENWISP_ORGANIZATON_USER_ADMIN', False)
-    or getattr(settings, 'OPENWISP_ORGANIZATION_USER_ADMIN', False)
-)
-ORGANIZATION_OWNER_ADMIN = (
-    # setting with typographic error for maintaining backward compatibility
-    # TODO: remove in openwisp-users 0.5
-    getattr(settings, 'OPENWISP_ORGANIZATON_OWNER_ADMIN', True)
-    or getattr(settings, 'OPENWISP_ORGANIZATON_OWNER_ADMIN', True)
-)
+ORGANIZATION_USER_ADMIN = getattr(settings, 'OPENWISP_ORGANIZATION_USER_ADMIN', False)
+ORGANIZATION_OWNER_ADMIN = getattr(settings, 'OPENWISP_ORGANIZATION_OWNER_ADMIN', True)
 USERS_AUTH_API = getattr(settings, 'OPENWISP_USERS_AUTH_API', False)
 USERS_AUTH_THROTTLE_RATE = getattr(
     settings,


### PR DESCRIPTION
Removed all the typographic errors for 0.5 release.

Also updated openwisp-utils to 0.7.0 in requirements.txt and
requirements-test.txt

Fixes #194