### PR TITLE
[deprecated] Removed User.organizations_pk #197

### DIFF
--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -60,24 +60,6 @@ class AbstractUser(BaseUser):
         abstract = True
         index_together = ('id', 'email')
 
-    @cached_property
-    def organizations_pk(self):
-        """
-        returns primary keys of organizations the user is associated to
-        """
-        logger.warn(
-            "User.organizations_pk is deprecated in favor of User.organizations_dict"
-            " and will be removed in a future version"
-        )
-        manager = load_model('openwisp_users', 'OrganizationUser').objects
-        qs = (
-            manager.filter(user=self, organization__is_active=True)
-            .select_related()
-            .only('organization_id')
-            .values_list('organization_id')
-        )
-        return qs
-
     @staticmethod
     def _get_pk(obj):
         """ meant for internal usage only """

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -43,20 +43,6 @@ class TestUsers(TestOrganizationMixin, TestCase):
         u.save()
         self.assertIsNone(u.email)
 
-    def test_organizations_pk(self):
-        user = self._create_user(username='organizations_pk')
-        org1 = self._create_org(name='org1')
-        org2 = self._create_org(name='org2')
-        self._create_org(name='org3')
-        OrganizationUser.objects.create(user=user, organization=org1)
-        OrganizationUser.objects.create(user=user, organization=org2)
-        self.assertIn((org1.pk,), user.organizations_pk)
-        self.assertEqual(len(user.organizations_pk), 2)
-
-    def test_organizations_pk_empty(self):
-        user = self._create_user(username='organizations_pk')
-        self.assertEqual(len(user.organizations_pk), 0)
-
     def test_organizations_dict(self):
         user = self._create_user(username='organizations_pk')
         self.assertEqual(user.organizations_dict, {})


### PR DESCRIPTION
Removed organizations_pk method from AbstractUser class
of openwisp_users.base.models.py.

Reason - User.organizations_pk is deprecated in favor of
         User.organizations_dict and will be removed in a
         future version

Fixes #197