### PR TITLE
[fix] Fixed test_organization_default_label breaking integration tests

### DIFF
--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -1381,29 +1381,6 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
             self.client.post(reverse(f'admin:{self.app_label}_user_add'), params)
             mocked.assert_called_once()
 
-    def test_organization_default_label(self):
-        admin = self._create_admin()
-        self.client.force_login(admin)
-        with self.subTest('Test required organization label'):
-            r = self.client.get(reverse('admin:testapp_book_add'))
-            self.assertContains(r, '<option value="" selected>---------</option>')
-
-        with self.subTest('Test optional organization label for superuser'):
-            r = self.client.get(reverse('admin:testapp_template_add'))
-            self.assertContains(
-                r, '<option value="" selected>Shared systemwide (no organization)',
-            )
-
-        with self.subTest('Test optional organization label for non-superuser'):
-            operator = self._create_operator()
-            template_permissions = Permission.objects.filter(codename='add_template')
-            operator.user_permissions.add(*template_permissions)
-            self.client.force_login(operator)
-            r = self.client.get(reverse('admin:testapp_template_add'))
-            self.assertNotContains(
-                r, 'Shared systemwide (no organization)',
-            )
-
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -1,0 +1,38 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+from django.urls import reverse
+from swapper import load_model
+
+from openwisp_users.tests.utils import TestOrganizationMixin
+
+Organization = load_model('openwisp_users', 'Organization')
+OrganizationUser = load_model('openwisp_users', 'OrganizationUser')
+OrganizationOwner = load_model('openwisp_users', 'OrganizationOwner')
+User = get_user_model()
+Group = load_model('openwisp_users', 'Group')
+
+
+class TestUsersAdmin(TestOrganizationMixin, TestCase):
+    def test_organization_default_label(self):
+        admin = self._create_admin()
+        self.client.force_login(admin)
+        with self.subTest('Test required organization label'):
+            r = self.client.get(reverse('admin:testapp_book_add'))
+            self.assertContains(r, '<option value="" selected>---------</option>')
+
+        with self.subTest('Test optional organization label for superuser'):
+            r = self.client.get(reverse('admin:testapp_template_add'))
+            self.assertContains(
+                r, '<option value="" selected>Shared systemwide (no organization)',
+            )
+
+        with self.subTest('Test optional organization label for non-superuser'):
+            operator = self._create_operator()
+            template_permissions = Permission.objects.filter(codename='add_template')
+            operator.user_permissions.add(*template_permissions)
+            self.client.force_login(operator)
+            r = self.client.get(reverse('admin:testapp_template_add'))
+            self.assertNotContains(
+                r, 'Shared systemwide (no organization)',
+            )


### PR DESCRIPTION
The test "test_organization_default_label" depends on a test app
which is not part of openwisp-users, therefore this test should
be shipped in the test app rather than openwisp-users, because
the tests of openwisp-users are imported and re-run in other
modules as integration tests, which test_organization_default_label
was breaking.

@Purhan see :point_up:  and https://github.com/openwisp/openwisp-radius/runs/1628664181.