### PR TITLE
[chores] Updated admin login template username label

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -668,7 +668,8 @@ Add ``openwisp_utils.staticfiles.DependencyFinder`` to
 5. Add ``openwisp_utils.loaders.DependencyLoader``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Add ``openwisp_utils.loaders.DependencyLoader`` to ``TEMPLATES`` in your ``settings.py``:
+Add ``openwisp_utils.loaders.DependencyLoader`` to ``TEMPLATES``
+before ``django.template.loaders.app_directories.Loader`` in your ``settings.py``:
 
 .. code-block:: python
 
@@ -678,8 +679,8 @@ Add ``openwisp_utils.loaders.DependencyLoader`` to ``TEMPLATES`` in your ``setti
             'OPTIONS': {
                 'loaders': [
                     'django.template.loaders.filesystem.Loader',
-                    'django.template.loaders.app_directories.Loader',
                     'openwisp_utils.loaders.DependencyLoader',
+                    'django.template.loaders.app_directories.Loader',
                 ],
                 'context_processors': [
                     'django.template.context_processors.debug',

--- a/openwisp_users/templates/admin/login.html
+++ b/openwisp_users/templates/admin/login.html
@@ -1,4 +1,5 @@
 {% extends "admin/login.html" %}
+{% load i18n %}
 {% block content %}
 {% if form.errors and not form.non_field_errors %}
 <p class="errornote">
@@ -28,7 +29,10 @@
 <form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
   <div class="form-row">
     {{ form.username.errors }}
-    {{ form.username.label_tag }} {{ form.username }}
+    <label class="required" for="id_username">
+      {% trans 'Email, phone number or username' %}:
+    </label>
+    {{ form.username }}
   </div>
   <div class="form-row">
     {{ form.password.errors }}

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -1479,6 +1479,18 @@ class TestBasicUsersIntegration(
     def test_delete_inline_owner_org_user(self):
         self._delete_inline_org_user(is_admin=True)
 
+    def test_login_page(self):
+        r = self.client.get(reverse('admin:login'))
+
+        with self.subTest('Test forgot password link'):
+            self.assertContains(
+                r, '<a href="/accounts/password/reset/">Forgot Password?</a>'
+            )
+
+        with self.subTest('Test username label'):
+            self.assertContains(r, '<label class="required" for="id_username">')
+            self.assertContains(r, 'Email, phone number or username:')
+
 
 class TestMultitenantAdmin(TestMultitenantAdminMixin, TestOrganizationMixin, TestCase):
     app_label = 'openwisp_users'

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -76,8 +76,8 @@ TEMPLATES = [
         'OPTIONS': {
             'loaders': [
                 'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
                 'openwisp_utils.loaders.DependencyLoader',
+                'django.template.loaders.app_directories.Loader',
             ],
             'context_processors': [
                 'django.template.context_processors.debug',


### PR DESCRIPTION
Mention that it's now possible to login using
the email or the phone number (provided the
authentication backend is correctly set as
indicated in the README).

Added also a test for the features of the custom
login.html admin template.