### PR TITLE
[change] Turn on API by default #203

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -217,7 +217,7 @@ Find out more information about `organization owners <#organization-owners>`_.
 +--------------+--------------+
 | **type**:    | ``boolean``  |
 +--------------+--------------+
-| **default**: | ``False``    |
+| **default**: | ``True``     |
 +--------------+--------------+
 
 Indicates whether the `REST API <#rest-api>`_ is enabled or not.

--- a/openwisp_users/settings.py
+++ b/openwisp_users/settings.py
@@ -3,7 +3,7 @@ from openwisp_utils.utils import default_or_test
 
 ORGANIZATION_USER_ADMIN = getattr(settings, 'OPENWISP_ORGANIZATION_USER_ADMIN', False)
 ORGANIZATION_OWNER_ADMIN = getattr(settings, 'OPENWISP_ORGANIZATION_OWNER_ADMIN', True)
-USERS_AUTH_API = getattr(settings, 'OPENWISP_USERS_AUTH_API', False)
+USERS_AUTH_API = getattr(settings, 'OPENWISP_USERS_AUTH_API', True)
 USERS_AUTH_THROTTLE_RATE = getattr(
     settings,
     'OPENWISP_USERS_AUTH_THROTTLE_RATE',

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -150,7 +150,6 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 SESSION_CACHE_ALIAS = 'default'
 
 OPENWISP_ORGANIZATION_USER_ADMIN = True
-OPENWISP_USERS_AUTH_API = True
 
 if os.environ.get('SAMPLE_APP', False):
     users_index = INSTALLED_APPS.index('openwisp_users')


### PR DESCRIPTION
Set the default value of USERS_AUTH_API in settings.py to true.
Updated the readme.

Closes #203