### PR TITLE
[fix] Fixed template exception if social account app not enabled #218

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ script:
   - ./run-qa-checks
   - coverage run --source=openwisp_users runtests.py
   - SAMPLE_APP=1 coverage run --append --source=openwisp_users runtests.py
+  # basic tests without allauth.socialaccount
+  - NO_SOCIAL_APP=1 ./tests/manage.py test testapp.tests.test_admin.TestUsersAdmin --parallel
 
 after_success:
   coveralls

--- a/openwisp_users/accounts/templates/account/login.html
+++ b/openwisp_users/accounts/templates/account/login.html
@@ -1,7 +1,6 @@
 {% extends "account/base.html" %}
 
 {% load i18n %}
-{% load account socialaccount %}
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
 {% block content %}

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -21,9 +21,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'openwisp_utils.admin_theme',
     # overrides some templates in django-allauth
     'openwisp_users.accounts',
+    'openwisp_utils.admin_theme',
     'django_extensions',
     'allauth',
     'allauth.account',
@@ -162,6 +162,9 @@ if os.environ.get('SAMPLE_APP', False):
     OPENWISP_USERS_ORGANIZATION_MODEL = 'sample_users.Organization'
     OPENWISP_USERS_ORGANIZATIONUSER_MODEL = 'sample_users.OrganizationUser'
     OPENWISP_USERS_ORGANIZATIONOWNER_MODEL = 'sample_users.OrganizationOwner'
+
+if os.environ.get('NO_SOCIAL_APP', False):
+    INSTALLED_APPS.remove('allauth.socialaccount')
 
 # local settings must be imported before test runner otherwise they'll be ignored
 try:

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -36,3 +36,8 @@ class TestUsersAdmin(TestOrganizationMixin, TestCase):
             self.assertNotContains(
                 r, 'Shared systemwide (no organization)',
             )
+
+    def test_accounts_login(self):
+        r = self.client.get(reverse('account_login'), follow=True)
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, '<button class="primaryAction" type="submit">')


### PR DESCRIPTION
Fixed 500 internal server error in /accounts/login/ if
allauth.socialaccount is not in INSTALLED_APPS.

Closes #218