### PR TITLE
[fix] Fixed - Exception raised on opening non existing user ID #228

### DIFF
--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -409,8 +409,8 @@ class UserAdmin(MultitenantAdminMixin, BaseUserAdmin, BaseAdmin):
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         extra_context = extra_context or {}
-        obj = self.model.objects.get(pk=object_id)
-        if user_not_allowed_to_change_owner(request.user, obj):
+        obj = self.get_object(request, object_id)
+        if obj is not None and user_not_allowed_to_change_owner(request.user, obj):
             show_owner_warning = True
             extra_context.update({'show_owner_warning': show_owner_warning})
         return super().change_view(request, object_id, form_url, extra_context)


### PR DESCRIPTION
- Added a test to check the response status on navigating to a non-existing user change page
- Handled exceptions for an invalid UUID and a non-existing user

Fixes #228