### PR TITLE
[change] Make email lowercase when adding new user #227

### DIFF
--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -3,6 +3,7 @@ import uuid
 
 import django
 from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser as BaseUser
 from django.contrib.auth.models import UserManager as BaseUserManager
 from django.core.cache import cache
@@ -141,10 +142,21 @@ class AbstractUser(BaseUser):
         return self.__get_orgs('is_owner')
 
     def clean(self):
-        if self.email == '':
+        email = self.email
+        if email == '':
             self.email = None
         if self.phone_number == '':
             self.phone_number = None
+        if (
+            email
+            and get_user_model()
+            .objects.filter(email__iexact=email)
+            .exclude(pk=self.pk)
+            .exists()
+        ):
+            raise ValidationError(
+                {'email': _('User with this Email address already exists.')}
+            )
 
     @property
     def permissions(self):

--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -3,7 +3,6 @@ import uuid
 
 import django
 from allauth.account.models import EmailAddress
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser as BaseUser
 from django.contrib.auth.models import UserManager as BaseUserManager
 from django.core.cache import cache
@@ -142,15 +141,13 @@ class AbstractUser(BaseUser):
         return self.__get_orgs('is_owner')
 
     def clean(self):
-        email = self.email
-        if email == '':
+        if self.email == '':
             self.email = None
         if self.phone_number == '':
             self.phone_number = None
         if (
-            email
-            and get_user_model()
-            .objects.filter(email__iexact=email)
+            self.email
+            and self._meta.model.objects.filter(email__iexact=self.email)
             .exclude(pk=self.pk)
             .exists()
         ):


### PR DESCRIPTION
### Why:
[RFC 5321](https://tools.ietf.org/rfc/rfc5321.txt) states that the `user` in `user@hostname` of an email format is case-sensitive. `USER@example.com` and `user@example.com` are therefore different email addresses (the domain is case-insensitive).

### Changes:
- Overrode the save method of the `AbstractUser` model to make the email lowercase.
- Added a test to check that email is lowered.
- Added a test to ensure that an Integrity error is raised if a new user is created with an existing mail but different case.
- Modified `UserCreationForm`to check if the case-sensitive mail already exists.

Fixes #227