### PR TITLE
[change] Always unregister restframework.authtoken TokenProxy model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,13 +87,13 @@ Setup (integrate in an existing django project)
         'allauth',
         'allauth.account',
         'allauth.socialaccount',
+        'rest_framework',
+        'rest_framework.authtoken',
         # must come before the django admin
         # to override the admin login page
         'openwisp_users',
         'django.contrib.admin',
         'django.contrib.sites',
-        'rest_framework',
-        'rest_framework.authtoken',
         'drf_yasg',
     ]
 

--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -665,14 +665,11 @@ if allauth_settings.SOCIALACCOUNT_ENABLED:
     ]:
         admin.site.unregister(apps.get_model(*model))
 
-
-if (
-    'rest_framework.authtoken' in settings.INSTALLED_APPS and not settings.DEBUG
-):  # pragma: no cover
-    Token = apps.get_model('authtoken', 'Token')
+if 'rest_framework.authtoken' in settings.INSTALLED_APPS:  # pragma: no cover
+    TokenProxy = apps.get_model('authtoken', 'TokenProxy')
 
     try:
-        admin.site.unregister(Token)
+        admin.site.unregister(TokenProxy)
     except NotRegistered:
         pass
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -30,11 +30,11 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     # must come before the django admin
     # to override the admin login page
+    'rest_framework',
+    'rest_framework.authtoken',
     'openwisp_users',
     'django.contrib.admin',
     'django.contrib.sites',
-    'rest_framework',
-    'rest_framework.authtoken',
     'drf_yasg',
     'testapp',
     'reversion',


### PR DESCRIPTION
Latest version of DRF changed Token to TokenProxy.
Let's always unregister it (also during development) to
keep consistency across all openwisp modules.