### PR TITLE
[feature] Recognize phone numbers in authentication backend #245

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,16 @@ Features
   see `Authentication Backend <https://github.com/openwisp/openwisp-users#authentication-backend>`_
 - Added possibility to filter users by their organization in
   the user administration section
+- Added phone number parsing to the authentication backend.
+  The value inserted by users as their identifier is parsed with the ``phonenumbers``
+  library to understand if it's a phone number, in which case the phone number
+  lookup is given priority.
+  This also allows recognizing the phone number if it contains additional
+  characters like spaces, dashes or dots.
+- If any international prefix is specified in the setting
+  ``OPENWISP_USERS_AUTH_BACKEND_AUTO_PREFIXES``, the authentication backend
+  tries prepending the listed prefixes when parsing numbers, so that users
+  can authenticate by typing only their national phone number.
 
 Changes
 ~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -241,6 +241,26 @@ also count valid requests for rate limiting. For more information,
 check Django-rest-framework
 `throttling guide <https://www.django-rest-framework.org/api-guide/throttling/>`_.
 
+``OPENWISP_USERS_AUTH_BACKEND_AUTO_PREFIXES``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++--------------+--------------+
+| **type**:    | ``tuple``    |
++--------------+--------------+
+| **default**: | ``tuple()``  |
++--------------+--------------+
+
+A tuple or list of international prefixes which will be automatically
+tested by `the authentication backend of openwisp-users <#authentication-backend>`_
+when parsing phone numbers.
+
+Each prefix will be prepended to the username string automatically and
+parsed with the ``phonenumbers`` library to find out if the result
+is a valid number of not.
+
+This allows users to log in by using only the national phone number,
+without having to specify the international prefix.
+
 REST API
 --------
 
@@ -504,16 +524,29 @@ The authentication backend in ``openwisp_users.backends.UsersAuthenticationBacke
 allows users to authenticate using their
 ``email`` or ``phone_number`` instead of their ``username``.
 Authenticating with the ``username`` is still allowed,
-but ``email`` and ``phone_number`` have precedence.
+but ``email`` has precedence.
 
-It can be used as follows:
+If the username string passed is parsed as a valid phone number, then
+``phone_number`` has precedence.
+
+Phone numbers are parsed using the ``phonenumbers`` library, which means
+that even if the user adds characters like spaces, dots or dashes, the number
+will be recognized anyway.
+
+When parsing phone numbers, the
+`OPENWISP_USERS_AUTH_BACKEND_AUTO_PREFIXES <#openwisp_users_auth_backend_auto_prefixes>`_
+setting allows to specify a list of international prefixes that can
+be prepended to the username string automatically in order to allow
+users to log in without having to type the international prefix.
+
+The authentication backend can also be used as follows::
 
 .. code-block:: python
 
     from openwisp_users.backends import UsersAuthenticationBackend
 
     backend = UsersAuthenticationBackend()
-    backend.authenticate(request, phone_number, password)
+    backend.authenticate(request, identifier, password)
 
 Django REST Framework Permission Classes
 ----------------------------------------

--- a/openwisp_users/backends.py
+++ b/openwisp_users/backends.py
@@ -1,6 +1,10 @@
+import phonenumbers
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.db.models import Q
+from phonenumbers.phonenumberutil import NumberParseException
+
+from . import settings as app_settings
 
 User = get_user_model()
 
@@ -19,6 +23,20 @@ class UsersAuthenticationBackend(ModelBackend):
         return None
 
     def get_users(self, identifier):
-        return User.objects.filter(
-            Q(email=identifier) | Q(phone_number=identifier) | Q(username=identifier)
-        )
+        conditions = Q(email=identifier) | Q(username=identifier)
+        # if the identifier is a phone number, use the phone number as primary condition
+        phone_number = self._get_phone_number(identifier)
+        if phone_number:
+            conditions = Q(phone_number=phone_number) | conditions
+        return User.objects.filter(conditions)
+
+    def _get_phone_number(self, identifier):
+        prefixes = [''] + list(app_settings.AUTH_BACKEND_AUTO_PREFIXES)
+        for prefix in prefixes:
+            value = f'{prefix}{identifier}'
+            try:
+                phonenumbers.parse(value)
+                return value
+            except NumberParseException:
+                pass
+        return False

--- a/openwisp_users/settings.py
+++ b/openwisp_users/settings.py
@@ -9,3 +9,6 @@ USERS_AUTH_THROTTLE_RATE = getattr(
     'OPENWISP_USERS_AUTH_THROTTLE_RATE',
     default_or_test(value='20/day', test=None),
 )
+AUTH_BACKEND_AUTO_PREFIXES = getattr(
+    settings, 'OPENWISP_USERS_AUTH_BACKEND_AUTO_PREFIXES', tuple()
+)

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -1313,7 +1313,10 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
             params.update(self._get_org_edit_form_inline_params(self._get_admin(), org))
             self.client.force_login(self._get_admin())
             user3 = self._create_user(
-                username='user3', password='user3', email='email3@email.com', is_staff=True
+                username='user3',
+                password='user3',
+                email='email3@email.com',
+                is_staff=True,
             )
             user3.groups.set(group)
             org_user3 = self._create_org_user(

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -1184,7 +1184,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
     def test_can_change_org(self):
         org = self._get_org()
         user = self._create_user(
-            username='change', password='change', email='email@email', is_staff=True
+            username='change', password='change', email='email@email.com', is_staff=True
         )
         group = Group.objects.filter(name='Administrator')
         user.groups.set(group)
@@ -1214,7 +1214,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
 
     def test_only_superuser_has_add_delete_org_perm(self):
         user = self._create_user(
-            username='change', password='change', email='email@email', is_staff=True
+            username='change', password='change', email='email@email.com', is_staff=True
         )
         group = Group.objects.filter(name='Administrator')
         user.groups.set(group)
@@ -1267,10 +1267,10 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
 
     def test_can_change_inline_org_owner(self):
         user1 = self._create_user(
-            username='user1', password='user1', email='email1@email', is_staff=True
+            username='user1', password='user1', email='email1@email.com', is_staff=True
         )
         user2 = self._create_user(
-            username='user2', password='user2', email='email2@email', is_staff=True
+            username='user2', password='user2', email='email2@email.com', is_staff=True
         )
         group = Group.objects.filter(name='Administrator')
         user1.groups.set(group)
@@ -1313,7 +1313,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
             params.update(self._get_org_edit_form_inline_params(self._get_admin(), org))
             self.client.force_login(self._get_admin())
             user3 = self._create_user(
-                username='user3', password='user3', email='email3@email', is_staff=True
+                username='user3', password='user3', email='email3@email.com', is_staff=True
             )
             user3.groups.set(group)
             org_user3 = self._create_org_user(
@@ -1328,7 +1328,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
     def test_only_superuser_can_delete_inline_org_owner(self):
         org = self._get_org()
         user = self._create_user(
-            username='change', password='change', email='email@email', is_staff=True
+            username='change', password='change', email='email@email.com', is_staff=True
         )
         group = Group.objects.filter(name='Administrator')
         user.groups.set(group)
@@ -1345,7 +1345,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
             user1 = self._create_user(
                 username='change1',
                 password='change1',
-                email='email1@email',
+                email='email1@email.com',
                 is_staff=True,
             )
             user1.groups.set(group)

--- a/openwisp_users/tests/test_backends.py
+++ b/openwisp_users/tests/test_backends.py
@@ -75,7 +75,7 @@ class TestBackends(TestOrganizationMixin, TestCase):
         )
         self._test_user_auth_backend_helper(user.phone_number, 'tester', user.pk)
 
-    def test_auth_backend_get_user(self):
+    def test_auth_backend_get_users(self):
         user = self._create_user(
             username='tester',
             email='tester@gmail.com',

--- a/openwisp_users/tests/utils.py
+++ b/openwisp_users/tests/utils.py
@@ -136,8 +136,9 @@ class TestOrganizationMixin(object):
             birth_date=date(1987, 3, 23),
         )
         opts.update(kwargs)
-        user = User.objects.create_user(**opts)
-        return user
+        user = User(**opts)
+        user.full_clean()
+        return User.objects.create_user(**opts)
 
     def _create_admin(self, **kwargs):
         opts = dict(


### PR DESCRIPTION
- Added phone number parsing to the authentication backend.
  The value inserted by users as their idenifier is parsed with ``phonenumbers``
  library to understand if it's a phone number, in which case the phone number
  lookup is given priority.
  This also allows recognizing the phone number if it contains additional
  characters like spaces, dashes or dots.
- If any international prefix is specified in the setting
  ``OPENWISP_USERS_AUTH_BACKEND_AUTO_PREFIXES``, the authentication backend
  tries prepending the listed prefixes when parsing numbers, so that users
  can authenticate by typing only their national phone number.

Closes #245.