### PR TITLE
[change!] Removed custom permission helpers #266

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -348,7 +348,7 @@ Organization Owners
 
 An organization owner is a user who is designated as the owner
 of a particular organization and this owner can not be deleted
-or edited by other administrators. Only the superuser has the permissions to do this.
+or edited by other administrators, only superusers have the permission to do this.
 
 By default, the first manager of an organization is designated as the owner of that organization.
 
@@ -476,47 +476,6 @@ Usage example:
     >>> user.organizations_owned
     ... ['20135c30-d486-4d68-993f-322b8acb51c4']
 
-Permissions helpers
--------------------
-
-The ``User`` model provides methods to check permissions in an efficient way
-(without generating database queries each time the permissions are accessed).
-
-``permissions``
-~~~~~~~~~~~~~~~
-
-The ``permissions`` property helper returns the user's permissions
-from the cache, cache invalidation is handled automatically.
-
-.. code-block:: python
-
-    >>> user.permissions
-    ... {'account.add_emailaddress',
-         'account.change_emailaddress',
-         'account.delete_emailaddress',
-         'account.view_emailaddress',
-         'openwisp_users.add_organizationuser',
-         'openwisp_users.add_user',
-         'openwisp_users.change_organizationuser',
-         'openwisp_users.change_user',
-         'openwisp_users.delete_organizationuser',
-         'openwisp_users.delete_user'}
-
-``has_permission(permission)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For superusers, the method returns ``True`` regardless of the permission passed to it.
-While for other users, the method checks whether the user has the specified permission and
-returns ``True`` or ``False`` accordingly.
-
-It uses the `permissions property helper <#permissions>`_ under the hood
-to avoid generating database queries each time is called.
-
-.. code-block:: python
-
-    >>> user.has_permission('openwisp_users.add_user')
-    ... True
-
 Authentication Backend
 ----------------------
 
@@ -606,7 +565,7 @@ in these cases to avoid generating too many queries.
 The default ``DjangoModelPermissions`` class doesn't checks for the
 ``view`` permission of any object for ``GET`` requests. The extended
 ``DjangoModelPermissions`` class overcomes this problem. In order to
-allow ``GET`` requests on any object it checks for the availability 
+allow ``GET`` requests on any object it checks for the availability
 of either ``view`` or ``change`` permissions.
 
 Usage example:

--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -155,25 +155,6 @@ class AbstractUser(BaseUser):
                 {'email': _('User with this Email address already exists.')}
             )
 
-    @property
-    def permissions(self):
-        """
-        Returns the user permissions from the cache, if the cache is
-        empty it will call self.get_all_permissions() and cache the result
-        """
-        cache_key = f'user_{self.pk}_permissions'
-        permissions = cache.get(cache_key)
-        if permissions is not None:
-            return permissions
-        permissions = self.get_all_permissions()
-        cache.set(cache_key, permissions)
-        return permissions
-
-    def has_permission(self, permission):
-        if self.is_superuser:
-            return True
-        return permission in self.permissions
-
 
 # on django 3.1, the max length of first_name has been changed, we need to
 # backport this change to the previous versions to avoid migration issues

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from swapper import load_model
@@ -9,7 +8,6 @@ from .utils import TestOrganizationMixin
 Organization = load_model('openwisp_users', 'Organization')
 OrganizationUser = load_model('openwisp_users', 'OrganizationUser')
 OrganizationOwner = load_model('openwisp_users', 'OrganizationOwner')
-Group = load_model('openwisp_users', 'Group')
 User = get_user_model()
 
 
@@ -204,64 +202,6 @@ class TestUsers(TestOrganizationMixin, TestCase):
         self.assertIsNone(user1.phone_number)
         self.assertIsNone(user2.phone_number)
         self.assertEqual(self.user_model.objects.filter(phone_number=None).count(), 2)
-
-    def test_cache_user_permission(self):
-        user = self.user_model(
-            username='user', email='email1@email.com', password='user1', is_staff=True
-        )
-        user.full_clean()
-        user.save()
-        group = Group.objects.filter(name='Administrator')
-        user.groups.set(group)
-
-        with self.subTest('Test cached permissions'):
-            with self.assertNumQueries(0):
-                user.permissions
-            self.assertEqual(user.get_all_permissions(), user.permissions)
-
-        with self.subTest('Test group permissions changed'):
-            self.assertIn('account.view_emailaddress', user.permissions)
-            permission = Permission.objects.get(codename='view_emailaddress')
-            g = group.first()
-            g.permissions.remove(permission.pk)
-            g.refresh_from_db()
-            self.assertNotIn('account.view_emailaddress', user.permissions)
-
-        with self.subTest('Test group changed'):
-            user.groups.remove(group.first().pk)
-            user.groups.set(Group.objects.filter(name='Operator'))
-            with self.assertNumQueries(0):
-                self.assertEqual(user.get_all_permissions(), user.permissions)
-
-        with self.subTest('Test user permission changed'):
-            permission = Permission.objects.filter(codename='add_organization')
-            user.user_permissions.add(*permission)
-            with self.assertNumQueries(0):
-                self.assertEqual(user.get_all_permissions(), user.permissions)
-
-    def test_operator_has_permission(self):
-        app_label = 'account'
-        user = self.user_model(
-            username='user', email='email1@email.com', password='user1', is_staff=True
-        )
-        user.full_clean()
-        user.save()
-        group = Group.objects.filter(name='Administrator')
-        user.groups.set(group)
-        self.assertFalse(user.has_permission(f'{app_label}.view_wrong'))
-        self.assertTrue(user.has_permission(f'{app_label}.view_emailaddress'))
-
-    def test_superuser_has_permission(self):
-        user = self.user_model(
-            username='superuser',
-            email='email@email.com',
-            password='test',
-            is_staff=True,
-            is_superuser=True,
-        )
-        user.full_clean()
-        user.save()
-        self.assertTrue(user.has_permission('not_found.not_found'))
 
     def test_user_get_pk(self):
         org = Organization.objects.first()


### PR DESCRIPTION
This code was introduced because of a misunderstanding.
It's not only not necessary but also buggy, better remove it and
use the permission helpers provided by Django.

Closes #266