### PR TITLE
[fix] User token endpoint #303

### DIFF
--- a/openwisp_users/api/urls.py
+++ b/openwisp_users/api/urls.py
@@ -46,7 +46,7 @@ def get_api_urls(api_views=None):
     ]
     if app_settings.USERS_AUTH_API:
         urlpatterns += [
-            path('user/token/', views.obtain_auth_token, name='user_auth_token')
+            path('users/token/', views.obtain_auth_token, name='user_auth_token')
         ]
     return urlpatterns
 


### PR DESCRIPTION
- Verified locally and change `user/token` to  `users/token` (Maintain endpoints consistency)

Fixes #303