### PR TITLE
[change/api] Organization managers and owners can view shared objects #238

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -808,9 +808,11 @@ Usage example:
         permission_classes = (DjangoModelPermissions,)
         queryset = Template.objects.all()
 
-**Note:** ``DjangoModelPermissions`` allows *read-only* access to
-organization owners and managers for *shared objects*.
-Normal organization users *do not* have access to shared objects.
+**Note:** ``DjangoModelPermissions`` allows users who
+are either organization managers or owners to view
+shared objects in read only mode.
+
+Standard users will not be able to view or list shared objects.
 
 Django REST Framework Mixins
 ----------------------------

--- a/README.rst
+++ b/README.rst
@@ -808,6 +808,10 @@ Usage example:
         permission_classes = (DjangoModelPermissions,)
         queryset = Template.objects.all()
 
+**Note:** ``DjangoModelPermissions`` allows *read-only* access to
+organization owners and managers for *shared objects*.
+Normal organization users *do not* have access to shared objects.
+
 Django REST Framework Mixins
 ----------------------------
 

--- a/openwisp_users/api/mixins.py
+++ b/openwisp_users/api/mixins.py
@@ -9,9 +9,12 @@ Organization = swapper.load_model('openwisp_users', 'Organization')
 
 class OrgLookup:
     @property
+    def org_field(self):
+        return getattr(self, 'organization_field', 'organization')
+
+    @property
     def organization_lookup(self):
-        org_field = getattr(self, 'organization_field', 'organization')
-        return f'{org_field}__in'
+        return f'{self.org_field}__in'
 
 
 class FilterByOrganization(OrgLookup):
@@ -35,9 +38,11 @@ class FilterByOrganization(OrgLookup):
     def get_organization_queryset(self, qs):
         if self.request.user.is_anonymous:
             return
-        return qs.filter(
-            **{self.organization_lookup: getattr(self.request.user, self._user_attr)}
-        )
+        organizations = getattr(self.request.user, self._user_attr)
+        conditions = Q(**{self.organization_lookup: organizations})
+        if len(organizations):
+            conditions |= Q(**{f'{self.org_field}__isnull': True})
+        return qs.filter(conditions)
 
 
 class FilterByOrganizationMembership(FilterByOrganization):

--- a/tests/testapp/tests/test_permission_classes.py
+++ b/tests/testapp/tests/test_permission_classes.py
@@ -288,8 +288,8 @@ class TestPermissionClasses(TestMultitenancyMixin, TestCase):
             self.assertEqual(response.status_code, expected_status_codes['option'])
 
     def test_superuser_access_shared_object(self):
-        admin = self._get_admin()
-        token = self._obtain_auth_token(username=admin)
+        superuser = self._get_admin()
+        token = self._obtain_auth_token(username=superuser)
         self._test_non_superuser_access_shared_object(
             token,
             expected_status_codes={
@@ -304,12 +304,12 @@ class TestPermissionClasses(TestMultitenancyMixin, TestCase):
         )
 
     def test_org_manager_access_shared_object(self):
-        operator = self._get_operator()
-        token = self._obtain_auth_token(username=operator)
+        org_manager = self._get_operator()
+        token = self._obtain_auth_token(username=org_manager)
         # First user is automatically owner, so created dummy
         # user to keep operator as manager only.
         self._create_org_user(user=self._get_user(), is_admin=True)
-        self._create_org_user(user=operator, is_admin=True)
+        self._create_org_user(user=org_manager, is_admin=True)
         self._test_non_superuser_access_shared_object(
             token,
             expected_status_codes={
@@ -324,9 +324,11 @@ class TestPermissionClasses(TestMultitenancyMixin, TestCase):
         )
 
     def test_org_owner_access_shared_object(self):
-        operator = self._get_operator()
-        token = self._obtain_auth_token(username=operator)
-        self._create_org_user(user=operator, is_admin=True)
+        org_owner = self._get_operator()
+        token = self._obtain_auth_token(username=org_owner)
+        # The first admin of an organization automatically
+        # becomes organization owner.
+        self._create_org_user(user=org_owner, is_admin=True)
         self._test_non_superuser_access_shared_object(
             token,
             expected_status_codes={
@@ -341,9 +343,12 @@ class TestPermissionClasses(TestMultitenancyMixin, TestCase):
         )
 
     def test_org_user_access_shared_object(self):
-        operator = self._get_operator()
-        token = self._obtain_auth_token(username=operator)
-        self._create_org_user(user=operator, is_admin=False)
+        # The test uses a user with operator permissions,
+        # because Django's model permission will deny permissions
+        # to the view and this test won't test "shared object" permissions.
+        user = self._get_operator()
+        token = self._obtain_auth_token(username=user)
+        self._create_org_user(user=user, is_admin=False)
         self._test_non_superuser_access_shared_object(
             token,
             expected_templates_count=0,


### PR DESCRIPTION
Updated API permissions classes to allow organization managers and
organization owners to view shared objects.

Related to #238