### PR TITLE
[fix] Fixed user's organization cache invalidation #327

### DIFF
--- a/openwisp_users/apps.py
+++ b/openwisp_users/apps.py
@@ -113,6 +113,10 @@ class OpenwispUsersConfig(AppConfig):
                         name, model.__name__
                     ),
                 )
+            # If the user related field of these models change for an object,
+            # then we need to invalidate the organization dict cache of the
+            # old user. Otherwise, cache will show that the old user is
+            # still related to the organization.
             pre_save.connect(
                 self.pre_save_update_organizations_dict,
                 sender=model,

--- a/openwisp_users/tests/test_api/test_api.py
+++ b/openwisp_users/tests/test_api/test_api.py
@@ -109,7 +109,7 @@ class TestUsersApi(
         org1_user1 = self._create_org_user(user=user1, organization=org1)
         path = reverse('users:organization_detail', args=(org1.pk,))
         data = {'owner': {'organization_user': org1_user1.pk}}
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(17):
             r = self.client.patch(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data['owner']['organization_user'], org1_user1.pk)
@@ -165,7 +165,7 @@ class TestUsersApi(
         self.assertEqual(org1.owner.organization_user.id, org1_user1.id)
         path = reverse('users:organization_detail', args=(org1.pk,))
         data = {'owner': {'organization_user': org1_user2.id}}
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(26):
             r = self.client.patch(path, data, content_type='application/json')
         org1.refresh_from_db()
         self.assertEqual(org1.owner.organization_user.id, org1_user2.id)


### PR DESCRIPTION
Invalidate user's organizations cache, if
OrganizationUser.user or OrganizationOwner.organization_user field are changed.

Fixes #327