### PR TITLE
[change] Added `org_id` to the validation of organization endpoint #329

### DIFF
--- a/openwisp_users/api/serializers.py
+++ b/openwisp_users/api/serializers.py
@@ -39,7 +39,7 @@ class OrganizationSerializer(ValidatedModelSerializer):
         Custom validation error if an organization
         already exists with the given slug.
         """
-        org = Organization.objects.filter(slug=data.get('slug')).first()
+        org = Organization.objects.filter(slug__exact=data.get('slug')).first()
         if org:
             raise serializers.ValidationError(
                 {
@@ -47,7 +47,7 @@ class OrganizationSerializer(ValidatedModelSerializer):
                     'organization': org.pk,
                 }
             )
-        return data
+        return super().validate(data)
 
 
 class CustomPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):

--- a/openwisp_users/api/serializers.py
+++ b/openwisp_users/api/serializers.py
@@ -19,12 +19,6 @@ OrganizationOwner = load_model('openwisp_users', 'OrganizationOwner')
 
 
 class OrganizationSerializer(ValidatedModelSerializer):
-    slug = serializers.SlugField(
-        allow_unicode=False,
-        help_text=_('The name in all lowercase, suitable for URL identification'),
-        max_length=200,
-    )
-
     class Meta:
         model = Organization
         fields = (
@@ -38,6 +32,7 @@ class OrganizationSerializer(ValidatedModelSerializer):
             'created',
             'modified',
         )
+        extra_kwargs = {'slug': {'validators': []}}
 
     def validate(self, data):
         """
@@ -48,8 +43,8 @@ class OrganizationSerializer(ValidatedModelSerializer):
         if org:
             raise serializers.ValidationError(
                 {
-                    'slug': [_('organization with this slug already exists.')],
-                    'org_id': [org.id],
+                    'slug': _('organization with this slug already exists.'),
+                    'organization': org.pk,
                 }
             )
         return data

--- a/openwisp_users/api/serializers.py
+++ b/openwisp_users/api/serializers.py
@@ -32,6 +32,8 @@ class OrganizationSerializer(ValidatedModelSerializer):
             'created',
             'modified',
         )
+        # This allows replacing the default "UniqueValidator" for
+        # the slug field with the custom validation defined below.
         extra_kwargs = {'slug': {'validators': []}}
 
     def validate(self, data):

--- a/openwisp_users/api/serializers.py
+++ b/openwisp_users/api/serializers.py
@@ -19,6 +19,12 @@ OrganizationOwner = load_model('openwisp_users', 'OrganizationOwner')
 
 
 class OrganizationSerializer(ValidatedModelSerializer):
+    slug = serializers.SlugField(
+        allow_unicode=False,
+        help_text=_('The name in all lowercase, suitable for URL identification'),
+        max_length=200,
+    )
+
     class Meta:
         model = Organization
         fields = (
@@ -32,6 +38,21 @@ class OrganizationSerializer(ValidatedModelSerializer):
             'created',
             'modified',
         )
+
+    def validate(self, data):
+        """
+        Custom validation error if an organization
+        already exists with the given slug.
+        """
+        org = Organization.objects.filter(slug=data.get('slug')).first()
+        if org:
+            raise serializers.ValidationError(
+                {
+                    'slug': [_('organization with this slug already exists.')],
+                    'org_id': [org.id],
+                }
+            )
+        return data
 
 
 class CustomPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):

--- a/openwisp_users/tests/test_api/test_api.py
+++ b/openwisp_users/tests/test_api/test_api.py
@@ -49,7 +49,7 @@ class TestUsersApi(
     def test_organization_post_api(self):
         path = reverse('users:organization_list')
         data = {'name': 'test-org', 'slug': 'test-org'}
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(4):
             r = self.client.post(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Organization.objects.count(), 2)
@@ -689,3 +689,17 @@ class TestUsersApi(
                 r = self.client.patch(path, data, content_type='application/json')
             self.assertEqual(r.status_code, 200)
             self.assertEqual(r.data['username'], 'changetestuser')
+
+    def test_organization_slug_post_custom_validation_api(self):
+        path = reverse('users:organization_list')
+        data = {'name': 'test-org', 'slug': 'test-org'}
+        with self.assertNumQueries(4):
+            r = self.client.post(path, data, content_type='application/json')
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(Organization.objects.count(), 2)
+        # try to create a new organization with the same slug
+        data = {'name': 'test-org', 'slug': 'test-org'}
+        r = self.client.post(path, data, content_type='application/json')
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(Organization.objects.count(), 2)
+        self.assertListEqual(list(r.data.keys()), ['slug', 'org_id'])

--- a/openwisp_users/tests/test_api/test_api.py
+++ b/openwisp_users/tests/test_api/test_api.py
@@ -49,7 +49,7 @@ class TestUsersApi(
     def test_organization_post_api(self):
         path = reverse('users:organization_list')
         data = {'name': 'test-org', 'slug': 'test-org'}
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(6):
             r = self.client.post(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Organization.objects.count(), 2)
@@ -693,7 +693,7 @@ class TestUsersApi(
     def test_organization_slug_post_custom_validation_api(self):
         path = reverse('users:organization_list')
         data = {'name': 'test-org', 'slug': 'test-org'}
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(6):
             r = self.client.post(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Organization.objects.count(), 2)

--- a/openwisp_users/tests/test_api/test_api.py
+++ b/openwisp_users/tests/test_api/test_api.py
@@ -698,8 +698,7 @@ class TestUsersApi(
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Organization.objects.count(), 2)
         # try to create a new organization with the same slug
-        data = {'name': 'test-org', 'slug': 'test-org'}
         r = self.client.post(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 400)
         self.assertEqual(Organization.objects.count(), 2)
-        self.assertListEqual(list(r.data.keys()), ['slug', 'org_id'])
+        self.assertListEqual(list(r.data.keys()), ['slug', 'organization'])


### PR DESCRIPTION
![Screenshot from 2023-01-04 16-56-59](https://user-images.githubusercontent.com/56113566/210545480-335f4703-cefd-4253-b1a9-83178bf4422d.png)


- Added `org_id` to the validation when an organization already exists with the given slug.
- Added tests.

Closes #329