### PR TITLE
[fix] Fixed browsable api custom theme

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
+    'openwisp_users',
     # openwisp2 admin theme
     # (must be loaded here)
     'openwisp_utils.admin_theme',
@@ -40,7 +41,6 @@ INSTALLED_APPS = [
     # to override the admin login page
     'rest_framework',
     'rest_framework.authtoken',
-    'openwisp_users',
     'django.contrib.admin',
     'admin_auto_filters',
     'django.contrib.sites',

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -33,12 +33,14 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
+    # openwisp2 admin theme
+    # (must be loaded here)
+    'openwisp_utils.admin_theme',
     # must come before the django admin
     # to override the admin login page
     'rest_framework',
     'rest_framework.authtoken',
     'openwisp_users',
-    'openwisp_utils.admin_theme',
     'django.contrib.admin',
     'admin_auto_filters',
     'django.contrib.sites',


### PR DESCRIPTION
- While working on https://github.com/openwisp/openwisp-users/pull/334, I discovered that the openwisp custom admin theme is not visible on browsable API webpages; see below: 

![Screenshot from 2023-01-05 17-45-11](https://user-images.githubusercontent.com/56113566/210778039-118a6c89-492e-4815-9448-13a19befef70.png)
