### PR TITLE
[chores] Added `.coverage.*` files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+# When running coverage testing 
+# it creates .coverage-username.123x* files
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
- When running coverage testing, it creates `.coverage.*` files, this change will exclude them from git.

![Screenshot from 2023-01-05 18-05-49](https://user-images.githubusercontent.com/56113566/210781908-4e987f2f-25c6-4a94-afcf-70a57fae9ff9.png)
