### PR TITLE
[fix] Fixed bug in UserAdmin when staff user manages multiple orgs

### DIFF
--- a/openwisp_users/multitenancy.py
+++ b/openwisp_users/multitenancy.py
@@ -112,7 +112,7 @@ class MultitenantAdminMixin(object):
                         f'{User._meta.app_label}_organizationuser__organization__in'
                     ): user.organizations_managed
                 }
-            )
+            ).distinct()
             # hide superusers from organization operators
             # so they can't edit nor delete them
             qs = qs.filter(is_superuser=False)

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -1773,11 +1773,8 @@ class TestMultitenantAdmin(TestMultitenantAdminMixin, TestOrganizationMixin, Tes
         self._create_org_user(organization=other_org, user=staff, is_admin=True)
         self._create_org_user(organization=staff_org, user=staff, is_admin=True)
         self._login(staff.username)
-        self._test_multitenant_admin(
-            url=reverse(f'admin:{self.app_label}_user_change', args=[staff.pk]),
-            hidden=[],
-            visible=[staff.username],
-        )
+        response = self.client.get(reverse(f'admin:{self.app_label}_user_changelist'))
+        self.assertContains(response, staff.email, count=1)
 
     def test_class_attr_regression(self):
         class TestAdmin(MultitenantAdminMixin):

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -1762,6 +1762,23 @@ class TestMultitenantAdmin(TestMultitenantAdminMixin, TestOrganizationMixin, Tes
             visible=[staff.username],
         )
 
+    def test_staff_user_manager_of_multiple_orgs_bug(self):
+        staff = self._create_user(
+            username='staff__user', email='staff@staff.org', is_staff=True
+        )
+        staff_org = self._create_org(name='staff_org')
+        other_org = Organization.objects.create(name='other org', slug='other-org')
+        admin_group = Group.objects.get(name='Administrator')
+        staff.groups.add(admin_group)
+        self._create_org_user(organization=other_org, user=staff, is_admin=True)
+        self._create_org_user(organization=staff_org, user=staff, is_admin=True)
+        self._login(staff.username)
+        self._test_multitenant_admin(
+            url=reverse(f'admin:{self.app_label}_user_change', args=[staff.pk]),
+            hidden=[],
+            visible=[staff.username],
+        )
+
     def test_class_attr_regression(self):
         class TestAdmin(MultitenantAdminMixin):
             multitenant_parent = 'test'


### PR DESCRIPTION
Without this patch it is possible that the system will return multiple identical results for a staff user who manages multiple orgs.

Fixes #324.