### PR TITLE
fix: Organization.add_user INTEGRITY error

### DIFF
--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -206,6 +206,22 @@ class BaseOrganization(models.Model):
     class Meta:
         abstract = True
 
+    def add_user(self, user, is_admin=False, **kwargs):
+        """
+        We override this method from the upstream dependency to
+        skip the creation of the organization owner, which we perform
+        automatically via a signal receiver.
+        Without this change, the add_user method would throw IntegrityError.
+        """
+
+        if not self.users.all().exists():
+            is_admin = True
+
+        OrganizationUser = load_model('openwisp_users', 'OrganizationUser')
+        return OrganizationUser.objects.create(
+            user=user, organization=self, is_admin=is_admin
+        )
+
 
 class BaseOrganizationUser(models.Model):
     """

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -334,9 +334,9 @@ class TestUsers(TestOrganizationMixin, TestCase):
         with self.subTest('Test user first and last names are empty'):
             self.assertEqual(str(org_user), f'{user.username} ({org.name})')
 
-    def test_add_user_method(self):
+    def test_add_user(self):
         org = self._get_org()
         user = self._create_user()
         org_user = org.add_user(user)
-
         self.assertIsInstance(org_user, OrganizationUser)
+        self.assertTrue(org_user.is_admin)

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -333,3 +333,10 @@ class TestUsers(TestOrganizationMixin, TestCase):
 
         with self.subTest('Test user first and last names are empty'):
             self.assertEqual(str(org_user), f'{user.username} ({org.name})')
+
+    def test_add_user_method(self):
+        org = self._get_org()
+        user = self._create_user()
+        org_user = org.add_user(user)
+
+        self.assertIsInstance(org_user, OrganizationUser)


### PR DESCRIPTION
since this project uses 'add_user' method of 'django-organizations' package, I catched the specific integrity error so that I don't interfere with the imported package internals.

Fixes #360