### PR TITLE
[fix] Use org_name argument in all cases

### DIFF
--- a/openwisp_users/tests/utils.py
+++ b/openwisp_users/tests/utils.py
@@ -186,7 +186,7 @@ class TestOrganizationMixin(object):
         try:
             return Organization.objects.get(name=org_name)
         except Organization.DoesNotExist:
-            return self._create_org()
+            return self._create_org(name=org_name)
 
     def _get_user(self, username='tester'):
         try:


### PR DESCRIPTION
Without this, providing a custom organization name does not work.