### PR TITLE
[change] Enable OrganizationUserAdmin by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,14 +202,11 @@ Settings
 +--------------+------------------+
 | **type**:    | ``boolean``      |
 +--------------+------------------+
-| **default**: | ``False``        |
+| **default**: | ``True``         |
 +--------------+------------------+
 
 Indicates whether the admin section for managing ``OrganizationUser`` items
 is enabled or not.
-
-It is disabled by default because these items can be managed via inline items
-in the user administration section.
 
 ``OPENWISP_ORGANIZATION_OWNER_ADMIN``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -83,8 +83,7 @@ class RequiredInlineFormSet(BaseInlineFormSet):
 class OrganizationOwnerInline(admin.StackedInline):
     model = OrganizationOwner
     extra = 0
-    if app_settings.ORGANIZATION_USER_ADMIN and app_settings.ORGANIZATION_OWNER_ADMIN:
-        autocomplete_fields = ('organization_user',)
+    autocomplete_fields = ('organization_user',)
 
     def has_change_permission(self, request, obj=None):
         if obj and not request.user.is_superuser and not request.user.is_owner(obj):
@@ -498,7 +497,9 @@ class OrganizationAdmin(
     MultitenantAdminMixin, BaseOrganizationAdmin, BaseAdmin, UUIDAdmin
 ):
     view_on_site = False
-    inlines = [OrganizationOwnerInline]
+    # this inline has an autocomplete field pointing to OrganizationUserAdmin
+    if app_settings.ORGANIZATION_USER_ADMIN and app_settings.ORGANIZATION_OWNER_ADMIN:
+        inlines = [OrganizationOwnerInline]
     readonly_fields = ['uuid', 'created', 'modified']
     ordering = ['name']
     list_display = ['name', 'is_active', 'created', 'modified']

--- a/openwisp_users/apps.py
+++ b/openwisp_users/apps.py
@@ -41,7 +41,7 @@ class OpenwispUsersConfig(AppConfig):
                 'name': 'changelist',
                 'icon': 'ow-org',
             },
-            5: {
+            3: {
                 'label': _('Groups & Permissions'),
                 'model': get_model_name(self.app_label, 'Group'),
                 'name': 'changelist',
@@ -49,14 +49,14 @@ class OpenwispUsersConfig(AppConfig):
             },
         }
         if app_settings.ORGANIZATION_OWNER_ADMIN:
-            items[3] = {
+            items[4] = {
                 'label': _('Organization Owners'),
                 'model': get_model_name(self.app_label, 'OrganizationOwner'),
                 'name': 'changelist',
                 'icon': 'ow-org-owner',
             }
         if app_settings.ORGANIZATION_USER_ADMIN:
-            items[4] = {
+            items[5] = {
                 'label': _('Organization Users'),
                 'model': get_model_name(self.app_label, 'OrganizationUser'),
                 'name': 'changelist',

--- a/openwisp_users/settings.py
+++ b/openwisp_users/settings.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from openwisp_utils.utils import default_or_test
 
-ORGANIZATION_USER_ADMIN = getattr(settings, 'OPENWISP_ORGANIZATION_USER_ADMIN', False)
+ORGANIZATION_USER_ADMIN = getattr(settings, 'OPENWISP_ORGANIZATION_USER_ADMIN', True)
 ORGANIZATION_OWNER_ADMIN = getattr(settings, 'OPENWISP_ORGANIZATION_OWNER_ADMIN', True)
 USERS_AUTH_API = getattr(settings, 'OPENWISP_USERS_AUTH_API', True)
 USERS_AUTH_THROTTLE_RATE = getattr(

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -163,8 +163,6 @@ else:
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 SESSION_CACHE_ALIAS = 'default'
 
-OPENWISP_ORGANIZATION_USER_ADMIN = True
-
 if SAMPLE_APP:
     users_index = INSTALLED_APPS.index('openwisp_users')
     INSTALLED_APPS.insert(users_index, 'openwisp2.sample_users')


### PR DESCRIPTION
If OrganizationUserAdmin is disabled, `OrganizationOwnerInline` was loading a select with all the users in the DB, which doesn't work on large databases.

This change enables this admin page by default and avoids loading the `OrganizationOwnerInline` if `OrganizationUserAdmin` is disabled.