### PR TITLE
[fix] Fix has_password_expired when password_update is None

### DIFF
--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -93,7 +93,7 @@ class AbstractUser(BaseUser):
         return super().set_password(*args, **kwargs)
 
     def has_password_expired(self):
-        if not self.has_usable_password():
+        if not self.has_usable_password() or self.password_updated is None:
             return False
         if self.is_staff and app_settings.STAFF_USER_PASSWORD_EXPIRATION:
             expiry_date = self.password_updated + timezone.timedelta(


### PR DESCRIPTION
The `password_updated` field can be `None`, so trying to perform an addition on it before ensuring the value is not `None` can lead to uncaught exceptions, this patch fixes this issue.