### PR TITLE
[fix] Invalidate org membership cache when organization is_active flag is changed #357

### DIFF
--- a/openwisp_users/apps.py
+++ b/openwisp_users/apps.py
@@ -105,9 +105,9 @@ class OpenwispUsersConfig(AppConfig):
         ]
 
         pre_save.connect(
-            self.handle_organization_update,
+            self.handle_org_is_active_change,
             sender=Organization,
-            dispatch_uid='handle_organization_is_active_change',
+            dispatch_uid='handle_org_is_active_change',
         )
 
         for model in [OrganizationUser, OrganizationOwner]:
@@ -138,7 +138,10 @@ class OpenwispUsersConfig(AppConfig):
         )
 
     @classmethod
-    def handle_organization_update(cls, instance, **kwargs):
+    def handle_org_is_active_change(cls, instance, **kwargs):
+        if instance._state.adding:
+            # If it's a new organization, we don't need to update any cache
+            return
         Organization = instance._meta.model
         try:
             old_instance = Organization.objects.only('is_active').get(pk=instance.pk)

--- a/openwisp_users/apps.py
+++ b/openwisp_users/apps.py
@@ -3,7 +3,7 @@ import logging
 from django.apps import AppConfig
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError,ObjectDoesNotExist
 from django.db import IntegrityError, transaction
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.utils.translation import gettext_lazy as _
@@ -98,10 +98,17 @@ class OpenwispUsersConfig(AppConfig):
     def connect_receivers(self):
         OrganizationUser = load_model('openwisp_users', 'OrganizationUser')
         OrganizationOwner = load_model('openwisp_users', 'OrganizationOwner')
+        Organization = load_model("openwisp_users" , "Organization") 
         signal_tuples = [
             (post_save, 'post_save'),
             (post_delete, 'post_delete'),
         ]
+
+        pre_save.connect(
+            self.handle_organization_update,
+            sender = Organization,
+            dispatch_uid='handle_organization_is_active_change'
+        )
 
         for model in [OrganizationUser, OrganizationOwner]:
             for signal, name in signal_tuples:
@@ -129,6 +136,22 @@ class OpenwispUsersConfig(AppConfig):
             sender=OrganizationUser,
             dispatch_uid='make_first_org_user_org_owner',
         )
+
+    @classmethod
+    def handle_organization_update(cls , instance , sender,**kwargs)  :
+        Organization = load_model("openwisp_users" , "Organization")
+        OrganizationUsers = load_model("openwisp_users" ,"OrganizationUser")
+        try:
+            old_obj = Organization.objects.get(pk=instance.pk)
+        except ObjectDoesNotExist:
+            logger.warning(f"Organization with pk {instance.pk} does not exist.")
+            return
+        except Exception as e:
+            logger.exception(f"An error occurred while fetching the organization: {e}")
+            return
+        if getattr(old_obj , "is_active") != getattr(instance , "is_active") :
+            for user in OrganizationUsers.objects.filter(organization = instance):
+                cls._invalidate_user_cache(user)
 
     @classmethod
     def pre_save_update_organizations_dict(cls, instance, **kwargs):

--- a/openwisp_users/tasks.py
+++ b/openwisp_users/tasks.py
@@ -97,8 +97,5 @@ def invalidate_org_membership_cache(organization_pk):
     qs = OrganizationUser.objects.filter(
         organization_id=organization_pk
     ).select_related('user')
-    User = get_user_model()
-    for user in qs.iterator():
-        if not isinstance(user, User):
-            user = user.user
-        user._invalidate_user_organizations_dict()
+    for org_user in qs.iterator():
+        org_user.user._invalidate_user_organizations_dict()

--- a/openwisp_users/tasks.py
+++ b/openwisp_users/tasks.py
@@ -17,6 +17,7 @@ from swapper import load_model
 from . import settings as app_settings
 
 User = get_user_model()
+OrganizationUser = load_model('openwisp_users', 'OrganizationUser')
 
 
 @shared_task
@@ -87,12 +88,13 @@ def password_expiration_email():
 
 
 @shared_task
-def organization_update_task(organization_pk):
+def invalidate_org_membership_cache(organization_pk):
     """
-    Invalidates cache of users when organization become inactive
+    Invalidates organization membership cache of all users of an
+    organization when organization.is_active changes
+    (organization is disabled or enabled again).
     """
-    OrganizationUsers = load_model('openwisp_users', 'OrganizationUser')
-    qs = OrganizationUsers.objects.filter(
+    qs = OrganizationUser.objects.filter(
         organization_id=organization_pk
     ).select_related('user')
     User = get_user_model()

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -1395,6 +1395,7 @@ class TestUsersAdmin(TestOrganizationMixin, TestUserAdditionalFieldsMixin, TestC
         params = {
             'name': org.name,
             'slug': org.slug,
+            'is_active': 'on',
             'owner-TOTAL_FORMS': '1',
             'owner-INITIAL_FORMS': '1',
             'owner-MIN_NUM_FORMS': '0',

--- a/openwisp_users/tests/test_api/test_api.py
+++ b/openwisp_users/tests/test_api/test_api.py
@@ -50,7 +50,7 @@ class TestUsersApi(
     def test_organization_post_api(self):
         path = reverse('users:organization_list')
         data = {'name': 'test-org', 'slug': 'test-org'}
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Organization.objects.count(), 2)
@@ -86,7 +86,7 @@ class TestUsersApi(
             'email': 'testorg@test.com',
             'url': '',
         }
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(8):
             r = self.client.put(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data['name'], 'test org change')
@@ -99,7 +99,7 @@ class TestUsersApi(
         data = {
             'name': 'test org change',
         }
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             r = self.client.patch(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data['name'], 'test org change')
@@ -110,7 +110,7 @@ class TestUsersApi(
         org1_user1 = self._create_org_user(user=user1, organization=org1)
         path = reverse('users:organization_detail', args=(org1.pk,))
         data = {'owner': {'organization_user': org1_user1.pk}}
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(18):
             r = self.client.patch(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data['owner']['organization_user'], org1_user1.pk)
@@ -122,7 +122,7 @@ class TestUsersApi(
         self._create_org_owner(organization_user=org1_user1, organization=org1)
         path = reverse('users:organization_detail', args=(org1.pk,))
         data = {'owner': {'organization_user': ''}}
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             r = self.client.patch(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data['owner'], None)
@@ -166,7 +166,7 @@ class TestUsersApi(
         self.assertEqual(org1.owner.organization_user.id, org1_user1.id)
         path = reverse('users:organization_detail', args=(org1.pk,))
         data = {'owner': {'organization_user': org1_user2.id}}
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(27):
             r = self.client.patch(path, data, content_type='application/json')
         org1.refresh_from_db()
         self.assertEqual(org1.owner.organization_user.id, org1_user2.id)
@@ -720,7 +720,7 @@ class TestUsersApi(
     def test_organization_slug_post_custom_validation_api(self):
         path = reverse('users:organization_list')
         data = {'name': 'test-org', 'slug': 'test-org'}
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Organization.objects.count(), 2)

--- a/openwisp_users/tests/test_api/test_api.py
+++ b/openwisp_users/tests/test_api/test_api.py
@@ -50,7 +50,7 @@ class TestUsersApi(
     def test_organization_post_api(self):
         path = reverse('users:organization_list')
         data = {'name': 'test-org', 'slug': 'test-org'}
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.post(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Organization.objects.count(), 2)
@@ -720,7 +720,7 @@ class TestUsersApi(
     def test_organization_slug_post_custom_validation_api(self):
         path = reverse('users:organization_list')
         data = {'name': 'test-org', 'slug': 'test-org'}
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.post(path, data, content_type='application/json')
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Organization.objects.count(), 2)

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -186,7 +186,7 @@ class TestUsers(TestOrganizationMixin, TestCase):
         self.assertEqual(user2.is_member(org), True)
 
     def test_invalidate_cache_org_status_changed(self):
-        org = self._create_org(name="testorg1")
+        org = self._create_org(name='testorg1')
         user1 = self._create_user(username='testuser1', email='user1@test.com')
         self._create_org_user(user=user1, organization=org)
         self.assertEqual(user1.is_member(org), True)

--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -185,6 +185,16 @@ class TestUsers(TestOrganizationMixin, TestCase):
         self.assertEqual(user1.is_member(org), False)
         self.assertEqual(user2.is_member(org), True)
 
+    def test_invalidate_cache_org_status_changed(self):
+        org = self._create_org(name="testorg1")
+        user1 = self._create_user(username='testuser1', email='user1@test.com')
+        self._create_org_user(user=user1, organization=org)
+        self.assertEqual(user1.is_member(org), True)
+        org.is_active = False
+        org.full_clean()
+        org.save()
+        self.assertEqual(user1.is_member(org), False)
+
     def test_organizations_managed(self):
         user = self._create_user(username='organizations_pk')
         self.assertEqual(user.organizations_managed, [])


### PR DESCRIPTION
When the status ( is_active ) of an organization changes it now invalidates the cache of all the organizationsusers.

Fixes https://github.com/openwisp/openwisp-users/issues/357.