### PR TITLE
[fix] Users registered with social login cannot set password #369

### DIFF
--- a/openwisp_users/accounts/templates/account/password_not_required.html
+++ b/openwisp_users/accounts/templates/account/password_not_required.html
@@ -1,0 +1,21 @@
+{% extends "account/base.html" %}
+{% load i18n %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+    .breadcrumbs, .messagelist {
+        display: none;
+    }
+    #content {
+        margin-top: 10px;
+    }
+    #site-name a { cursor: default }
+</style>
+{% endblock %}
+
+{% block content %}
+<h1>{% trans "You cannot change your password from this application because your account is linked to a third-party authentication provider." %}</h1>
+<h1>{% trans "Please visit the provider's website to manage your password." %}</h1>
+<h1>{% trans "This web page can be closed." %}</h1>
+{% endblock %}

--- a/openwisp_users/accounts/views.py
+++ b/openwisp_users/accounts/views.py
@@ -3,6 +3,7 @@ from allauth.account.views import PasswordChangeView as BasePasswordChangeView
 from django import forms
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
 from django.urls import reverse_lazy
 from django.views.generic.base import TemplateView
 
@@ -25,6 +26,13 @@ class PasswordChangeView(BasePasswordChangeView):
         data = super().get_initial()
         data['next'] = self.request.GET.get(REDIRECT_FIELD_NAME)
         return data
+
+    def render_to_response(self, context, **response_kwargs):
+        if not self.request.user.has_usable_password():
+            return render(self.request, 'account/password_not_required.html')
+        return super(PasswordChangeView, self).render_to_response(
+            context, **response_kwargs
+        )
 
 
 password_change = login_required(PasswordChangeView.as_view())

--- a/openwisp_users/tests/test_accounts.py
+++ b/openwisp_users/tests/test_accounts.py
@@ -94,3 +94,29 @@ class TestAccountView(TestOrganizationMixin, TestCase):
         self.assertContains(
             response, 'The username and/or password you specified are not correct.'
         )
+
+    def test_social_login_user_change_password(self):
+        """
+        Tests the scenario where a user registers with social login
+        and then accesses the change password view.
+        """
+        # This test simulates the scenario where a user signs up using
+        # social login. Social login users do not set a password, so to
+        # verify this behavior, we set an unusable password to the user
+        # object.
+        user = self._create_org_user().user
+        user.set_unusable_password()
+        user.save()
+        self.client.force_login(user)
+        response = self.client.get(reverse('account_change_password'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            (
+                '<h1>You cannot change your password from this application because'
+                ' your account is linked to a third-party authentication provider.</h1>'
+                '<h1>Please visit the provider\'s website to manage your password.</h1>'
+                '<h1>This web page can be closed.</h1>'
+            ),
+            html=True,
+        )


### PR DESCRIPTION
Users registered with social login would not have a password set. When they access the password change page, a message would be should to they users that they do not need to change password.

Closes #369