### PR TITLE
[fix:tests] Fixed flaky expected date in test_password_expiration_mail

### DIFF
--- a/openwisp_users/tests/test_models.py
+++ b/openwisp_users/tests/test_models.py
@@ -4,6 +4,7 @@ from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.exceptions import ValidationError
+from django.templatetags.l10n import localize
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import now, timedelta
@@ -442,7 +443,7 @@ class TestUsers(TestOrganizationMixin, TestCase):
                 password_updated=user_expiry_date
             )
             password_expiration_email.delay()
-            formatted_expiry_date = (now() + timedelta(days=7)).strftime('%-d %b %Y')
+            expected_date = localize((now() + timedelta(days=7)).date())
             self.assertEqual(len(mail.outbox), 1)
             email = mail.outbox.pop()
             self.assertEqual(email.to, [verified_email_user.email])
@@ -450,13 +451,13 @@ class TestUsers(TestOrganizationMixin, TestCase):
             self.assertEqual(
                 email.body,
                 'We inform you that the password for your account tester will expire'
-                f' in 7 days, precisely on {formatted_expiry_date}.\n\n'
+                f' in 7 days, precisely on {expected_date}.\n\n'
                 'Kindly proceed with updating your password by clicking on the'
                 ' button below.',
             )
             self.assertIn(
                 '<p>We inform you that the password for your account tester will expire'
-                f' in 7 days, precisely on {formatted_expiry_date}.<p>\n\n<p>',
+                f' in 7 days, precisely on {expected_date}.<p>\n\n<p>',
                 email.alternatives[0][0],
             )
             self.assertIn(


### PR DESCRIPTION
Build the expected date in the same way the django template framework does.