### PR TITLE
[fix] Don't allow organization admin to created shared object

### DIFF
--- a/openwisp_users/multitenancy.py
+++ b/openwisp_users/multitenancy.py
@@ -64,6 +64,7 @@ class MultitenantAdminMixin(object):
             * show only relevant organizations
             * show only relations associated to relevant organizations
               or shared relations
+            * do not allow organization field to be empty (shared org)
         else show everything
         """
         fields = form.base_fields
@@ -78,6 +79,7 @@ class MultitenantAdminMixin(object):
             if org_field:
                 org_field.queryset = org_field.queryset.filter(pk__in=orgs_pk)
                 org_field.empty_label = None
+                org_field.required = True
             # other relations
             q = Q(organization__in=orgs_pk) | Q(organization=None)
             for field_name in self.multitenant_shared_relations:

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -7,6 +7,8 @@ from swapper import load_model
 
 from openwisp_users.tests.utils import TestOrganizationMixin
 
+from ..models import Template
+
 Organization = load_model('openwisp_users', 'Organization')
 OrganizationUser = load_model('openwisp_users', 'OrganizationUser')
 OrganizationOwner = load_model('openwisp_users', 'OrganizationOwner')
@@ -40,3 +42,40 @@ class TestUsersAdmin(TestOrganizationMixin, TestCase):
         self.assertContains(
             r, '<input type="submit" class="button" value="Sign In" />', html=True
         )
+
+
+class TestTemplateAdmin(TestOrganizationMixin, TestCase):
+    def test_org_admin_create_shareable_template(self):
+        administrator = self._create_administrator()
+        self.client.force_login(administrator)
+        response = self.client.post(
+            reverse('admin:testapp_template_add'),
+            data={
+                'name': 'test-template',
+                'organization': '',
+            },
+            follow=True,
+        )
+        self.assertContains(
+            response,
+            (
+                '<div class="form-row errors field-organization">\n'
+                '            <ul class="errorlist"><li>This field '
+                'is required.</li></ul>'
+            ),
+        )
+        self.assertEqual(Template.objects.count(), 0)
+
+    def test_superuser_create_shareable_template(self):
+        admin = self._create_admin()
+        self.client.force_login(admin)
+        response = self.client.post(
+            reverse('admin:testapp_template_add'),
+            data={
+                'name': 'test-template',
+                'organization': '',
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Template.objects.count(), 1)


### PR DESCRIPTION
Organization admins should not be able to create objects that are shared between different organizations.