### PR TITLE
[deps] Added additional socialaccount dependencies for django-allauth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django-organizations~=2.4.1
 django-extensions~=3.2.3
-django-allauth~=0.63.6
+django-allauth[socialaccount]~=0.63.6
 django-phonenumber-field~=8.0.0
 phonenumbers~=8.13.42
 openwisp-utils[rest,celery]~=1.1.0


### PR DESCRIPTION
Without the extra packages, the user wouldn't be able to use social account providers out of the box.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

