### PR TITLE
Fix: Replace deprecated `index_together` with `indexes` for Django 5.0

### DIFF
--- a/openwisp_users/base/models.py
+++ b/openwisp_users/base/models.py
@@ -73,7 +73,9 @@ class AbstractUser(BaseUser):
 
     class Meta(BaseUser.Meta):
         abstract = True
-        index_together = ('id', 'email')
+        indexes = [
+        models.Index(fields=['id', 'email']),
+    ]
 
     @staticmethod
     def _get_pk(obj):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #433  .


**Changes**  
- Replaced `index_together` with `indexes` in `AbstractUser.Meta`.
- Maintained backward compatibility with older Django versions.

**Files Modified**  
- `openwisp_users/base/models.py`

## Screenshot
Before : ![Image](https://github.com/user-attachments/assets/c92b7b55-c7a4-4a50-b504-ca3798894441)
