### PR TITLE
[chores] Moved CSS for allauth templates to dedicated CSS

### DIFF
--- a/openwisp_users/accounts/static/openwisp-users/accounts/css/non-admin.css
+++ b/openwisp_users/accounts/static/openwisp-users/accounts/css/non-admin.css
@@ -1,0 +1,7 @@
+#content p {
+  margin: 10px 0;
+}
+button,
+form label {
+  margin-right: 5px;
+}

--- a/openwisp_users/accounts/templates/allauth/layouts/base.html
+++ b/openwisp_users/accounts/templates/allauth/layouts/base.html
@@ -1,4 +1,9 @@
 {% extends "admin/base_site.html" %}
+{% load static %}
 {% block title %}OpenWISP{% endblock %}
 
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'openwisp-users/accounts/css/non-admin.css' %}" />
+{% endblock %}
 {% block breadcrumbs %}{% endblock %}


### PR DESCRIPTION
This patch is placing some rules which have been removed from the openwisp-utils admin CSS in https://github.com/openwisp/openwisp-utils/pull/518 to a dedicated CSS file being loaded only in the allauth (non-admin) templates.

