### PR TITLE
[fix] Allowed managing social auth secrets when needed

### DIFF
--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -652,11 +652,14 @@ if admin.site.is_registered(EmailAddress):
     admin.site.unregister(EmailAddress)
 
 if allauth_settings.SOCIALACCOUNT_ENABLED:
-    for model in [
-        ("socialaccount", "SocialApp"),
+    socialaccount_models = [
         ("socialaccount", "SocialToken"),
         ("socialaccount", "SocialAccount"),
-    ]:
+    ]
+    # Allow managing secrets if OAuth/SAML is enabled
+    if not app_settings.SOCIALACCOUNT_ADMIN_NEEDED:
+        socialaccount_models.append(("socialaccount", "SocialApp"))
+    for model in socialaccount_models:
         model_class = apps.get_model(*model)
         if admin.site.is_registered(model_class):
             admin.site.unregister(model_class)

--- a/openwisp_users/settings.py
+++ b/openwisp_users/settings.py
@@ -49,3 +49,12 @@ setattr(
         "openwisp_users.views.AutocompleteJsonView",
     ),
 )
+
+# if OAuth/SAML is enabled, allow manging keys/secrets
+if any(
+    app.startswith("allauth.socialaccount.providers") for app in settings.INSTALLED_APPS
+):  # pragma: no cover
+    SOCIALACCOUNT_ADMIN_NEEDED = True
+# otherwise hide the socialaccount admin (not needed)
+else:
+    SOCIALACCOUNT_ADMIN_NEEDED = False


### PR DESCRIPTION
Before, OpenWISP Users removed the ``allauth.socialaccount`` admin sections to keep the admin UI simple, but over time more users need this to support OAuth/SAML authentication to the admin interface (manage app secrets).
With this change, the admin allows managing app secrets if any ``allauth.socialaccount.provider`` is installed, eg: microsoft, google, openid, etc.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.