### PR TITLE
[ci] Bound setuptools to <82 due to removal of pkg_resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           sudo apt update -qq
           sudo apt-get -qq -y install gettext
-          pip install -U pip wheel setuptools
+          pip install -U pip wheel "setuptools<82"
           pip install -U -r requirements-test.txt
           sudo npm install -g prettier
           pip install -e .[rest]


### PR DESCRIPTION
Fix CI for 1.2 branch / python 3.9.