### PR TITLE
[fix] Added SocialAccount inline to UserAdmin when needed

### DIFF
--- a/openwisp_users/accounts/urls.py
+++ b/openwisp_users/accounts/urls.py
@@ -77,12 +77,11 @@ urlpatterns = [
 
 if app_settings.SOCIALACCOUNT_ENABLED:
     urlpatterns += [path("social/", include("allauth.socialaccount.urls"))]
-
-for provider in providers.registry.get_class_list():
-    try:
-        prov_mod = import_module(provider.get_package() + ".urls")
-    except ImportError:
-        continue
-    prov_urlpatterns = getattr(prov_mod, "urlpatterns", None)
-    if prov_urlpatterns:
-        urlpatterns += prov_urlpatterns
+    for provider in providers.registry.get_class_list():
+        try:
+            prov_mod = import_module(provider.get_package() + ".urls")
+        except ImportError:
+            continue
+        prov_urlpatterns = getattr(prov_mod, "urlpatterns", None)
+        if prov_urlpatterns:
+            urlpatterns += prov_urlpatterns

--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -660,18 +660,38 @@ EmailAddress = apps.get_model("account", "EmailAddress")
 if admin.site.is_registered(EmailAddress):
     admin.site.unregister(EmailAddress)
 
-if allauth_settings.SOCIALACCOUNT_ENABLED:
-    socialaccount_models = [
-        ("socialaccount", "SocialToken"),
-        ("socialaccount", "SocialAccount"),
-    ]
-    # Allow managing secrets if OAuth/SAML is enabled
-    if not app_settings.SOCIALACCOUNT_ADMIN_NEEDED:
-        socialaccount_models.append(("socialaccount", "SocialApp"))
-    for model in socialaccount_models:
-        model_class = apps.get_model(*model)
-        if admin.site.is_registered(model_class):
-            admin.site.unregister(model_class)
+_unregister_socialaccount_models = [
+    ("socialaccount", "SocialToken"),
+    ("socialaccount", "SocialAccount"),
+]
+# allauth OAuth/SAML not enabled
+if (
+    allauth_settings.SOCIALACCOUNT_ENABLED
+    and not app_settings.SOCIALACCOUNT_ADMIN_NEEDED
+):  # pragma: no cover
+    _unregister_socialaccount_models.append(("socialaccount", "SocialApp"))
+# allauth OAuth/SAML enabled
+elif allauth_settings.SOCIALACCOUNT_ENABLED and app_settings.SOCIALACCOUNT_ADMIN_NEEDED:
+    from allauth.socialaccount.admin import SocialAccount
+
+    class SocialAccountInline(admin.StackedInline):
+        model = SocialAccount
+        extra = 0
+        readonly_fields = ("provider", "uid", "extra_data")
+
+        def has_add_permission(self, request, obj):
+            return False
+
+        def has_delete_permission(self, request, obj=None):
+            return False
+
+    UserAdmin.inlines.append(SocialAccountInline)
+
+# Un-register cluttering socialaccount models
+for model in _unregister_socialaccount_models:
+    model_class = apps.get_model(*model)
+    if admin.site.is_registered(model_class):
+        admin.site.unregister(model_class)
 
 if "rest_framework.authtoken" in settings.INSTALLED_APPS:  # pragma: no cover
     TokenProxy = apps.get_model("authtoken", "TokenProxy")

--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -660,38 +660,36 @@ EmailAddress = apps.get_model("account", "EmailAddress")
 if admin.site.is_registered(EmailAddress):
     admin.site.unregister(EmailAddress)
 
-_unregister_socialaccount_models = [
-    ("socialaccount", "SocialToken"),
-    ("socialaccount", "SocialAccount"),
-]
-# allauth OAuth/SAML not enabled
-if (
-    allauth_settings.SOCIALACCOUNT_ENABLED
-    and not app_settings.SOCIALACCOUNT_ADMIN_NEEDED
-):  # pragma: no cover
-    _unregister_socialaccount_models.append(("socialaccount", "SocialApp"))
-# allauth OAuth/SAML enabled
-elif allauth_settings.SOCIALACCOUNT_ENABLED and app_settings.SOCIALACCOUNT_ADMIN_NEEDED:
-    from allauth.socialaccount.admin import SocialAccount
+if allauth_settings.SOCIALACCOUNT_ENABLED:
+    _unregister_socialaccount_models = [
+        ("socialaccount", "SocialToken"),
+        ("socialaccount", "SocialAccount"),
+    ]
+    # allauth OAuth/SAML not enabled
+    if not app_settings.SOCIALACCOUNT_ADMIN_NEEDED:  # pragma: no cover
+        _unregister_socialaccount_models.append(("socialaccount", "SocialApp"))
+    # allauth OAuth/SAML enabled
+    else:
+        from allauth.socialaccount.models import SocialAccount
 
-    class SocialAccountInline(admin.StackedInline):
-        model = SocialAccount
-        extra = 0
-        readonly_fields = ("provider", "uid", "extra_data")
+        class SocialAccountInline(admin.StackedInline):
+            model = SocialAccount
+            extra = 0
+            readonly_fields = ("provider", "uid", "extra_data")
 
-        def has_add_permission(self, request, obj):
-            return False
+            def has_add_permission(self, request, obj=None):
+                return False
 
-        def has_delete_permission(self, request, obj=None):
-            return False
+            def has_delete_permission(self, request, obj=None):
+                return False
 
-    UserAdmin.inlines.append(SocialAccountInline)
+        UserAdmin.inlines.append(SocialAccountInline)
 
-# Un-register cluttering socialaccount models
-for model in _unregister_socialaccount_models:
-    model_class = apps.get_model(*model)
-    if admin.site.is_registered(model_class):
-        admin.site.unregister(model_class)
+    # Un-register cluttering socialaccount models
+    for model in _unregister_socialaccount_models:
+        model_class = apps.get_model(*model)
+        if admin.site.is_registered(model_class):
+            admin.site.unregister(model_class)
 
 if "rest_framework.authtoken" in settings.INSTALLED_APPS:  # pragma: no cover
     TokenProxy = apps.get_model("authtoken", "TokenProxy")

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -73,7 +73,7 @@ class TestUsersAdmin(
 
     @property
     def add_user_inline_params(self):
-        return {
+        params = {
             "emailaddress_set-TOTAL_FORMS": 0,
             "emailaddress_set-INITIAL_FORMS": 0,
             "emailaddress_set-MIN_NUM_FORMS": 0,
@@ -83,6 +83,19 @@ class TestUsersAdmin(
             f"{self.app_label}_organizationuser-MIN_NUM_FORMS": 0,
             f"{self.app_label}_organizationuser-MAX_NUM_FORMS": 0,
         }
+        self._add_socialaccount_inline_params(params)
+        return params
+
+    def _add_socialaccount_inline_params(self, params):
+        if app_settings.SOCIALACCOUNT_ADMIN_NEEDED:
+            params.update(
+                {
+                    "socialaccount_set-TOTAL_FORMS": 0,
+                    "socialaccount_set-INITIAL_FORMS": 0,
+                    "socialaccount_set-MIN_NUM_FORMS": 0,
+                    "socialaccount_set-MAX_NUM_FORMS": 0,
+                }
+            )
 
     def test_admin_add_user_auto_email(self):
         admin = self._create_admin()
@@ -1702,6 +1715,7 @@ class TestBasicUsersIntegration(
 
     app_label = "openwisp_users"
     is_integration_test = True
+    _add_socialaccount_inline_params = TestUsersAdmin._add_socialaccount_inline_params
 
     def _get_user_edit_form_inline_params(self, user, organization):
         params = {
@@ -1740,6 +1754,7 @@ class TestBasicUsersIntegration(
                     f"{self.app_label}_organizationuser-0-user": str(user.pk),
                 }
             )
+        self._add_socialaccount_inline_params(params)
         return params
 
     def test_change_user(self):

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
+    "allauth.socialaccount.providers.google",  # for test coverage
     "openwisp_users",
     # openwisp2 admin theme
     # (must be loaded here)


### PR DESCRIPTION
If SOCIALACCOUNT_ADMIN_NEEDED is True, admins should be able to manage the social account records of users.

## Reference to Existing Issue

Related  to #501.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.
