### PR TITLE
[chores:fix] Removed deprecated UUIDAdmin in favour of CopyableFieldsAdmin

### DIFF
--- a/openwisp_users/admin.py
+++ b/openwisp_users/admin.py
@@ -30,7 +30,7 @@ from organizations.exceptions import OwnershipRequired
 from phonenumber_field.formfields import PhoneNumberField
 from swapper import load_model
 
-from openwisp_utils.admin import UUIDAdmin
+from openwisp_utils.admin import CopyableFieldsAdmin
 
 from . import settings as app_settings
 from .multitenancy import MultitenantAdminMixin, MultitenantOrgFilter
@@ -505,7 +505,7 @@ class GroupAdmin(BaseGroupAdmin, BaseAdmin):
 
 
 class OrganizationAdmin(
-    MultitenantAdminMixin, BaseOrganizationAdmin, BaseAdmin, UUIDAdmin
+    MultitenantAdminMixin, BaseOrganizationAdmin, BaseAdmin, CopyableFieldsAdmin
 ):
     view_on_site = False
     # this inline has an autocomplete field pointing to OrganizationUserAdmin
@@ -514,6 +514,7 @@ class OrganizationAdmin(
     readonly_fields = ["uuid", "created", "modified"]
     ordering = ["name"]
     list_display = ["name", "is_active", "created", "modified"]
+    copyable_fields = ("uuid",)
 
     def get_inline_instances(self, request, obj=None):
         """
@@ -535,7 +536,7 @@ class OrganizationAdmin(
             return False
         return super().has_change_permission(request, obj)
 
-    class Media(UUIDAdmin.Media):
+    class Media(CopyableFieldsAdmin.Media):
         css = {"all": ("openwisp-users/css/admin.css",)}
 
 

--- a/openwisp_users/tests/test_admin.py
+++ b/openwisp_users/tests/test_admin.py
@@ -20,7 +20,7 @@ from swapper import load_model
 from openwisp_utils.tests import AdminActionPermTestMixin, capture_any_output
 
 from .. import settings as app_settings
-from ..admin import OrganizationOwnerAdmin
+from ..admin import OrganizationAdmin, OrganizationOwnerAdmin
 from ..apps import logger as apps_logger
 from ..multitenancy import MultitenantAdminMixin
 from .utils import (
@@ -1092,6 +1092,12 @@ class TestUsersAdmin(
         response = self.client.get(reverse(f"admin:{self.app_label}_organization_add"))
         html = '<input type="text" name="name" value="default"'
         self.assertNotContains(response, html)
+
+    def test_organization_admin_copyable_uuid(self):
+        org_admin = OrganizationAdmin(Organization, django_admin.site)
+        org = self._create_org()
+        self.assertEqual(OrganizationAdmin.copyable_fields, ("uuid",))
+        self.assertEqual(org_admin.uuid(org), org.pk)
 
     def test_action_active(self):
         user = User.objects.create(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Description of Changes

Replaced the deprecated `UUIDAdmin` mixin from `openwisp_utils` with `CopyableFieldsAdmin` in `OrganizationAdmin`. Added `copyable_fields = ("uuid",)` and a regression test to ensure the UUID field remains copyable in the admin interface.