### PR TITLE
[chores] Removed ValidatedModelSerializer workaround in SuperUserDetailSerializer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           pip install -U -r requirements-test.txt
           sudo npm install -g prettier
           pip install -e .[rest]
+          pip install --force-reinstall --no-deps "openwisp-utils @ https://github.com/BHARATH0153/openwisp-utils/archive/7eb5232ae2ed92c36a527e69f42143405a10e763.tar.gz"
           pip install -U ${{ matrix.django-version }}
 
       - name: QA checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
           pip install -U -r requirements-test.txt
           sudo npm install -g prettier
           pip install -e .[rest]
-          pip install --force-reinstall --no-deps "openwisp-utils @ https://github.com/BHARATH0153/openwisp-utils/archive/7eb5232ae2ed92c36a527e69f42143405a10e763.tar.gz"
           pip install -U ${{ matrix.django-version }}
 
       - name: QA checks

--- a/openwisp_users/api/serializers.py
+++ b/openwisp_users/api/serializers.py
@@ -1,10 +1,10 @@
 import logging
-from copy import copy, deepcopy
+from copy import deepcopy
 
 from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.db import models, transaction
+from django.db import transaction
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
@@ -339,20 +339,6 @@ class SuperUserDetailSerializer(BaseSuperUserSerializer):
             "last_login": {"read_only": True},
             "date_joined": {"read_only": True},
         }
-
-    # Workaround for https://github.com/openwisp/openwisp-utils/issues/633
-    # TODO: Remove when the Bug is fixed in openwisp-utils
-    def validate(self, data):
-        Model = self.Meta.model
-        instance = copy(self.instance) if self.instance else Model()
-        for key, value in data.items():
-            if key in self._skip_validation_fields:
-                continue
-            # avoid direct assignment for m2m (not allowed)
-            if not isinstance(Model._meta.get_field(key), models.ManyToManyField):
-                setattr(instance, key, value)
-        instance.full_clean(exclude=self.exclude_validation)
-        return data
 
     def update(self, instance, validated_data):
         org_user_data = dict()


### PR DESCRIPTION
## Description

Removes the workaround for openwisp/openwisp-utils#633 from `SuperUserDetailSerializer.validate()`. The fix is now handled in `ValidatedModelSerializer` (openwisp/openwisp-utils#679), so the override is no longer needed.

## Related Issues

Closes openwisp/openwisp-utils#633

## Checklist

- [x] I have read the OpenWISP Contributing Guidelines.
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.