### PR TITLE
[chores] Separated session redis bucket from cache bucket

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -142,7 +142,7 @@ if not TESTING and SHELL:
 
 
 if not TESTING:
-    CELERY_BROKER_URL = "redis://localhost/6"
+    CELERY_BROKER_URL = "redis://localhost/2"
 else:
     CELERY_TASK_ALWAYS_EAGER = True
     CELERY_TASK_EAGER_PROPAGATES = True
@@ -184,7 +184,12 @@ if not PARALLEL:
             "BACKEND": "django_redis.cache.RedisCache",
             "LOCATION": "redis://localhost/0",
             "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
-        }
+        },
+        "sessions": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://localhost/1",
+            "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+        },
     }
 # parallel testing with redis cache does not work
 # so we use the local memory cache in this case
@@ -195,11 +200,15 @@ else:
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "openwisp-users",
-        }
+        },
+        "sessions": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "openwisp-users-sessions",
+        },
     }
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-SESSION_CACHE_ALIAS = "default"
+SESSION_CACHE_ALIAS = "sessions"
 
 if SAMPLE_APP:
     users_index = INSTALLED_APPS.index("openwisp_users")

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -230,8 +230,3 @@ try:
     from .local_settings import *
 except ImportError:
     pass
-
-# Added for silencing warnings raised by django-all-auth
-# on Django 3.2 and above. Remove when new version of
-# django-all-auth is released
-SILENCED_SYSTEM_CHECKS = ["models.W042"]


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Not needed, small improvement being done in all repositories.

## Description of Changes

Small improvement to the test env which separates cache from session storage to avoid terminating sessions when clearing the cache.