### PR TITLE
[fix] Fixed get_api_urls for custom views #553

### DIFF
--- a/openwisp_users/api/urls.py
+++ b/openwisp_users/api/urls.py
@@ -9,44 +9,49 @@ def get_api_urls(api_views=None):
     urlpatterns = []
     if api_views is None:
         api_views = views
+
+    def get_view(name):
+        """Fall back to the standard view when a custom view is unavailable."""
+        return getattr(api_views, name, getattr(views, name))
+
     urlpatterns += [
         path(
             "users/organization/",
-            views.organization_list,
+            get_view("organization_list"),
             name="organization_list",
         ),
         path(
             "users/organization/<uuid:pk>/",
-            views.organization_detail,
+            get_view("organization_detail"),
             name="organization_detail",
         ),
         path(
             "users/user/",
-            views.user_list,
+            get_view("user_list"),
             name="user_list",
         ),
-        path("users/user/<uuid:pk>/", views.user_detail, name="user_detail"),
+        path("users/user/<uuid:pk>/", get_view("user_detail"), name="user_detail"),
         path(
             "users/user/<uuid:pk>/password/",
-            views.change_password,
+            get_view("change_password"),
             name="change_password",
         ),
         path(
             "users/user/<uuid:pk>/email/",
-            views.email_list,
+            get_view("email_list"),
             name="email_list",
         ),
         path(
             "users/user/<uuid:pk>/email/<int:email_id>/",
-            views.email_update,
+            get_view("email_update"),
             name="email_update",
         ),
-        path("users/group/", views.group_list, name="group_list"),
-        path("users/group/<int:pk>/", views.group_detail, name="group_detail"),
+        path("users/group/", get_view("group_list"), name="group_list"),
+        path("users/group/<int:pk>/", get_view("group_detail"), name="group_detail"),
     ]
     if app_settings.USERS_AUTH_API:
         urlpatterns += [
-            path("users/token/", views.obtain_auth_token, name="user_auth_token")
+            path("users/token/", get_view("obtain_auth_token"), name="user_auth_token")
         ]
     return urlpatterns
 

--- a/openwisp_users/api/views.py
+++ b/openwisp_users/api/views.py
@@ -156,7 +156,7 @@ class ChangePasswordView(BaseUserView, UpdateAPIView):
             self.permission_classes = [IsAuthenticated]
         else:
             self.permission_classes = [IsAuthenticated, DjangoModelPermissions]
-        return super(self.__class__, self).get_permissions()
+        return super().get_permissions()
 
     def get_object(self):
         if getattr(self, "swagger_fake_view", False):

--- a/openwisp_users/tests/test_api/test_urls.py
+++ b/openwisp_users/tests/test_api/test_urls.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from ...api import views
+from ...api.urls import get_api_urls
+
+
+class TestApiUrls(SimpleTestCase):
+    def test_get_api_urls_uses_overrides_and_default_fallbacks(self):
+        def custom_view(request):
+            return None
+
+        view_names = {
+            "organization_list": "organization_list",
+            "organization_detail": "organization_detail",
+            "user_list": "user_list",
+            "user_detail": "user_detail",
+            "change_password": "change_password",
+            "email_list": "email_list",
+            "email_update": "email_update",
+            "group_list": "group_list",
+            "group_detail": "group_detail",
+            "user_auth_token": "obtain_auth_token",
+        }
+        custom_views = SimpleNamespace(
+            **{
+                view_name: custom_view
+                for view_name in view_names.values()
+                if view_name != "email_list"
+            }
+        )
+        callbacks = {
+            pattern.name: pattern.callback for pattern in get_api_urls(custom_views)
+        }
+
+        for url_name, view_name in view_names.items():
+            with self.subTest(url_name=url_name):
+                expected = (
+                    views.email_list if view_name == "email_list" else custom_view
+                )
+                self.assertIs(callbacks[url_name], expected)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #553.

## Description of Changes

`get_api_urls()` now uses callbacks supplied by a custom API views module and falls back to standard views for callbacks the module does not define.

The change also fixes `ChangePasswordView` permission resolution for custom subclasses and adds regression coverage for custom callbacks and fallback behavior.

## Screenshot

N/A: this change only affects server-side URL configuration.