### PR TITLE
[feature] Allowed customizing Password Reset form #511

### DIFF
--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -278,3 +278,16 @@ Number of days before a user's ``expiration_date`` when OpenWISP sends an
 account expiration reminder email.
 
 If set to ``0``, reminder emails are disabled.
+
+``OPENWISP_USERS_PASSWORD_RESET_FORM``
+--------------------------------------
+
+============ =================================================
+**type**:    ``str``
+**default**: ``"openwisp_users.base.forms.PasswordResetForm"``
+============ =================================================
+
+Dotted path to the form used to deliver password reset messages. Override
+this setting to customize password recovery delivery, for example to send
+an SMS alongside email in deployments with custom password-expiration
+flows.

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -287,7 +287,6 @@ If set to ``0``, reminder emails are disabled.
 **default**: ``"openwisp_users.base.forms.PasswordResetForm"``
 ============ =================================================
 
-Dotted path to the form used to deliver password reset messages. Override
-this setting to customize password recovery delivery, for example to send
-an SMS alongside email in deployments with custom password-expiration
-flows.
+Dotted path to an OpenWISP Users-compatible password reset form. Configure
+a subclass of ``openwisp_users.base.forms.PasswordResetForm`` to customize
+password recovery delivery, for example to send an SMS alongside email.

--- a/openwisp_users/api/serializers.py
+++ b/openwisp_users/api/serializers.py
@@ -500,7 +500,8 @@ class PasswordResetSerializer(BasePasswordResetSerializer):
     email = None
     input = serializers.CharField()
 
-    def get_password_reset_form_class(self):
+    @property
+    def password_reset_form_class(self):
         return import_string(app_settings.PASSWORD_RESET_FORM)
 
     def validate_input(self, value):
@@ -511,8 +512,7 @@ class PasswordResetSerializer(BasePasswordResetSerializer):
         request = self.context["request"]
         view = self.context["view"]
         for user in self.users:
-            form_class = self.get_password_reset_form_class()
-            self.reset_form = form_class(data={"email": user.email})
+            self.reset_form = self.password_reset_form_class(data={"email": user.email})
             if not self.reset_form.is_valid():
                 continue
             opts = {

--- a/openwisp_users/api/serializers.py
+++ b/openwisp_users/api/serializers.py
@@ -14,13 +14,14 @@ from django.contrib.auth.models import Permission
 from django.contrib.sites.shortcuts import get_current_site
 from django.db import transaction
 from django.db.models import Q
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from swapper import load_model
 
 from openwisp_utils.api.serializers import ValidatedModelSerializer
 
-from ..base.forms import PasswordResetForm
+from .. import settings as app_settings
 
 Group = load_model("openwisp_users", "Group")
 Organization = load_model("openwisp_users", "Organization")
@@ -498,7 +499,9 @@ class PasswordResetSerializer(BasePasswordResetSerializer):
     # `input`, which accepts a username, e-mail address, or phone number.
     email = None
     input = serializers.CharField()
-    password_reset_form_class = PasswordResetForm
+
+    def get_password_reset_form_class(self):
+        return import_string(app_settings.PASSWORD_RESET_FORM)
 
     def validate_input(self, value):
         self.users = self.context["view"].get_users(value)
@@ -508,7 +511,8 @@ class PasswordResetSerializer(BasePasswordResetSerializer):
         request = self.context["request"]
         view = self.context["view"]
         for user in self.users:
-            self.reset_form = self.password_reset_form_class(data={"email": user.email})
+            form_class = self.get_password_reset_form_class()
+            self.reset_form = form_class(data={"email": user.email})
             if not self.reset_form.is_valid():
                 continue
             opts = {

--- a/openwisp_users/settings.py
+++ b/openwisp_users/settings.py
@@ -11,7 +11,8 @@ USERS_AUTH_THROTTLE_RATE = getattr(
     "OPENWISP_USERS_AUTH_THROTTLE_RATE",
     default_or_test(value="20/day", test=None),
 )
-# Allows applications to customize password reset delivery.
+# Allows applications to customize password reset form
+# (eg: SMS delivery of password reset link).
 PASSWORD_RESET_FORM = getattr(
     settings,
     "OPENWISP_USERS_PASSWORD_RESET_FORM",

--- a/openwisp_users/settings.py
+++ b/openwisp_users/settings.py
@@ -11,6 +11,12 @@ USERS_AUTH_THROTTLE_RATE = getattr(
     "OPENWISP_USERS_AUTH_THROTTLE_RATE",
     default_or_test(value="20/day", test=None),
 )
+# Allows applications to customize password reset delivery.
+PASSWORD_RESET_FORM = getattr(
+    settings,
+    "OPENWISP_USERS_PASSWORD_RESET_FORM",
+    "openwisp_users.base.forms.PasswordResetForm",
+)
 AUTH_BACKEND_AUTO_PREFIXES = getattr(
     settings, "OPENWISP_USERS_AUTH_BACKEND_AUTO_PREFIXES", tuple()
 )

--- a/openwisp_users/tests/test_api/test_password_reset.py
+++ b/openwisp_users/tests/test_api/test_password_reset.py
@@ -10,8 +10,10 @@ from django.urls import reverse_lazy
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 
+from openwisp_users import settings as app_settings
 from openwisp_users.api.throttling import AuthRateThrottle
 from openwisp_users.api.views import PasswordResetConfirmView
+from openwisp_users.base.forms import PasswordResetForm
 from openwisp_users.tests.utils import TestOrganizationMixin
 
 
@@ -70,6 +72,28 @@ class TestPasswordResetAPI(TestOrganizationMixin, TestCase):
                 self.assertEqual(len(mail.outbox), 1)
                 self.assertEqual(mail.outbox[0].to, [user.email])
                 mail.outbox.clear()
+
+    def test_reset_request_uses_configured_form(self):
+        class CustomPasswordResetForm(PasswordResetForm):
+            pass
+
+        user = self._create_user(username="tester", email="tester@example.com")
+        with (
+            patch.object(
+                app_settings,
+                "PASSWORD_RESET_FORM",
+                "test.CustomPasswordResetForm",
+            ),
+            patch(
+                "openwisp_users.api.serializers.import_string",
+                return_value=CustomPasswordResetForm,
+            ) as mocked_import_string,
+            patch.object(CustomPasswordResetForm, "send_mail") as mocked_send_mail,
+        ):
+            response = self.client.post(self.request_url, {"input": user.username})
+        self.assertEqual(response.status_code, 200)
+        mocked_import_string.assert_called_once_with("test.CustomPasswordResetForm")
+        mocked_send_mail.assert_called_once()
 
     def test_reset_request_without_input_fails(self):
         response = self.client.post(self.request_url, {})

--- a/openwisp_users/tests/test_api/test_views.py
+++ b/openwisp_users/tests/test_api/test_views.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.forms import PasswordResetForm as DjangoPasswordResetForm
 from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
@@ -109,14 +108,17 @@ class TestGetApiUrls(TestCase):
             with self.subTest(view=view.__name__):
                 self.assertIs(view.__dict__.get("serializer_class"), serializer)
 
-    def test_password_reset_form_is_configurable(self):
+    def test_password_reset_form_can_be_overridden(self):
+        class CustomPasswordResetForm(PasswordResetForm):
+            pass
+
         serializer = PasswordResetSerializer()
-        self.assertIs(serializer.get_password_reset_form_class(), PasswordResetForm)
-        with patch.object(
-            app_settings,
-            "PASSWORD_RESET_FORM",
-            "django.contrib.auth.forms.PasswordResetForm",
-        ):
-            self.assertIs(
-                serializer.get_password_reset_form_class(), DjangoPasswordResetForm
-            )
+        self.assertIs(serializer.password_reset_form_class, PasswordResetForm)
+
+        class CustomPasswordResetSerializer(PasswordResetSerializer):
+            password_reset_form_class = CustomPasswordResetForm
+
+        self.assertIs(
+            CustomPasswordResetSerializer().password_reset_form_class,
+            CustomPasswordResetForm,
+        )

--- a/openwisp_users/tests/test_api/test_views.py
+++ b/openwisp_users/tests/test_api/test_views.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import PasswordResetForm as DjangoPasswordResetForm
 from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
@@ -13,6 +14,7 @@ from openwisp_users.api.serializers import (
 )
 from openwisp_users.api.urls import get_api_urls
 from openwisp_users.api.views import PasswordChangeView, PasswordResetView
+from openwisp_users.base.forms import PasswordResetForm
 from openwisp_users.tests.utils import TestOrganizationMixin
 
 User = get_user_model()
@@ -106,3 +108,15 @@ class TestGetApiUrls(TestCase):
         for view, serializer in serializers_by_view:
             with self.subTest(view=view.__name__):
                 self.assertIs(view.__dict__.get("serializer_class"), serializer)
+
+    def test_password_reset_form_is_configurable(self):
+        serializer = PasswordResetSerializer()
+        self.assertIs(serializer.get_password_reset_form_class(), PasswordResetForm)
+        with patch.object(
+            app_settings,
+            "PASSWORD_RESET_FORM",
+            "django.contrib.auth.forms.PasswordResetForm",
+        ):
+            self.assertIs(
+                serializer.get_password_reset_form_class(), DjangoPasswordResetForm
+            )


### PR DESCRIPTION
## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Related to #511

## Description of Changes

Allows setting a different password reset Django form for downstream/custom third party implementations with alternative logic or delivery mechanisms, which was supported before but after the changes done to implement #511 it's no longer possible, so this new alternative, cleaner method is provided. 