### PR TITLE
[chores:fix] Fixed disabled authentication throttle regression

### DIFF
--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -67,15 +67,18 @@ Indicates whether the :doc:`rest-api` is enabled or not.
 ``OPENWISP_USERS_AUTH_THROTTLE_RATE``
 -------------------------------------
 
-============ ==========
-**type**:    ``str``
+============ ===================
+**type**:    ``str`` or ``None``
 **default**: ``20/day``
-============ ==========
+============ ===================
 
 Indicates the rate throttling for the :ref:`obtain_auth_token` API
 endpoint, as well as the :ref:`user_password_reset`,
 :ref:`user_password_reset_confirm` and :ref:`user_password_change`
 endpoints.
+
+Set this to ``None`` to disable authentication throttling. This does not
+fall back to Django REST framework's default throttle rates.
 
 Please note that the current rate throttler is very basic and will also
 count valid requests for rate limiting. For more information, check

--- a/openwisp_users/api/throttling.py
+++ b/openwisp_users/api/throttling.py
@@ -10,3 +10,9 @@ class AuthRateThrottle(UserRateThrottle):
     """
 
     rate = app_settings.USERS_AUTH_THROTTLE_RATE
+
+    def get_rate(self):
+        """
+        Return the dedicated auth rate without consulting DRF defaults.
+        """
+        return self.rate

--- a/openwisp_users/tests/test_api/test_throttling.py
+++ b/openwisp_users/tests/test_api/test_throttling.py
@@ -32,6 +32,7 @@ class RatelimitTests(APITestCase):
         url = reverse("users:user_auth_token")
         data = {"username": "operator", "password": "tester"}
         for rates in ({}, {"user": "1/day"}):
+
             with self.subTest(rates=rates), patch.object(
                 AuthRateThrottle, "THROTTLE_RATES", rates
             ):

--- a/openwisp_users/tests/test_api/test_throttling.py
+++ b/openwisp_users/tests/test_api/test_throttling.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core.cache import cache
 from django.urls import reverse
 
@@ -24,6 +26,16 @@ class RatelimitTests(APITestCase):
         self.assertEqual(r.status_code, 200)
         r = self.client.post(url, data)
         self.assertEqual(r.status_code, 429)
+
+    @patch.object(AuthRateThrottle, "THROTTLE_RATES", {})
+    def test_auth_rate_throttle_can_be_disabled(self):
+        AuthRateThrottle.rate = None
+        url = reverse("users:user_auth_token")
+        data = {"username": "operator", "password": "tester"}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
 
     def test_authenticated_password_change_is_rate_limited(self):
         AuthRateThrottle.rate = "1/day"

--- a/openwisp_users/tests/test_api/test_throttling.py
+++ b/openwisp_users/tests/test_api/test_throttling.py
@@ -27,15 +27,19 @@ class RatelimitTests(APITestCase):
         r = self.client.post(url, data)
         self.assertEqual(r.status_code, 429)
 
-    @patch.object(AuthRateThrottle, "THROTTLE_RATES", {})
     def test_auth_rate_throttle_can_be_disabled(self):
         AuthRateThrottle.rate = None
         url = reverse("users:user_auth_token")
         data = {"username": "operator", "password": "tester"}
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, 200)
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, 200)
+        for rates in ({}, {"user": "1/day"}):
+            with self.subTest(rates=rates), patch.object(
+                AuthRateThrottle, "THROTTLE_RATES", rates
+            ):
+                response = self.client.post(url, data)
+                self.assertEqual(response.status_code, 200)
+                response = self.client.post(url, data)
+                self.assertEqual(response.status_code, 200)
+                cache.clear()
 
     def test_authenticated_password_change_is_rate_limited(self):
         AuthRateThrottle.rate = "1/day"

--- a/openwisp_users/tests/test_api/test_throttling.py
+++ b/openwisp_users/tests/test_api/test_throttling.py
@@ -32,7 +32,6 @@ class RatelimitTests(APITestCase):
         url = reverse("users:user_auth_token")
         data = {"username": "operator", "password": "tester"}
         for rates in ({}, {"user": "1/day"}):
-
             with self.subTest(rates=rates), patch.object(
                 AuthRateThrottle, "THROTTLE_RATES", rates
             ):

--- a/tests/testapp/tests/test_filter_classes.py
+++ b/tests/testapp/tests/test_filter_classes.py
@@ -18,7 +18,8 @@ User = get_user_model()
 
 class TestFilterClasses(AssertNumQueriesSubTestMixin, TestMultitenancyMixin, TestCase):
     def setUp(self):
-        AuthRateThrottle.rate = 0
+        self._original_rate = AuthRateThrottle.rate
+        AuthRateThrottle.rate = None
         self.shelf_model = Shelf
         self.book_model = Book
         self.library_model = Library
@@ -45,6 +46,9 @@ class TestFilterClasses(AssertNumQueriesSubTestMixin, TestMultitenancyMixin, Tes
         self.book2 = self._create_book(
             name="book2", organization=self._get_org("org_a"), shelf=self.shelf_b
         )
+
+    def tearDown(self):
+        AuthRateThrottle.rate = self._original_rate
 
     def _assert_django_filters_shelf_options(self, response, shelf_a, shelf_b):
         self.assertEqual(response.data[0]["id"], str(shelf_a.id))

--- a/tests/testapp/tests/test_filter_classes.py
+++ b/tests/testapp/tests/test_filter_classes.py
@@ -19,6 +19,7 @@ User = get_user_model()
 class TestFilterClasses(AssertNumQueriesSubTestMixin, TestMultitenancyMixin, TestCase):
     def setUp(self):
         self._original_rate = AuthRateThrottle.rate
+        self.addCleanup(setattr, AuthRateThrottle, "rate", self._original_rate)
         AuthRateThrottle.rate = None
         self.shelf_model = Shelf
         self.book_model = Book
@@ -46,9 +47,6 @@ class TestFilterClasses(AssertNumQueriesSubTestMixin, TestMultitenancyMixin, Tes
         self.book2 = self._create_book(
             name="book2", organization=self._get_org("org_a"), shelf=self.shelf_b
         )
-
-    def tearDown(self):
-        AuthRateThrottle.rate = self._original_rate
 
     def _assert_django_filters_shelf_options(self, response, shelf_a, shelf_b):
         self.assertEqual(response.data[0]["id"], str(shelf_a.id))

--- a/tests/testapp/tests/test_permission_classes.py
+++ b/tests/testapp/tests/test_permission_classes.py
@@ -16,11 +16,15 @@ OrganizationUser = load_model("openwisp_users", "OrganizationUser")
 
 class TestPermissionClasses(TestMultitenancyMixin, TestCase):
     def setUp(self):
-        AuthRateThrottle.rate = 0
+        self._original_rate = AuthRateThrottle.rate
+        AuthRateThrottle.rate = None
         self.template_model = Template
         self.member_url = reverse("test_api_member_view")
         self.manager_url = reverse("test_api_manager_view")
         self.owner_url = reverse("test_api_owner_view")
+
+    def tearDown(self):
+        AuthRateThrottle.rate = self._original_rate
 
     def test_operator_none(self):
         self._get_operator()

--- a/tests/testapp/tests/test_permission_classes.py
+++ b/tests/testapp/tests/test_permission_classes.py
@@ -17,14 +17,12 @@ OrganizationUser = load_model("openwisp_users", "OrganizationUser")
 class TestPermissionClasses(TestMultitenancyMixin, TestCase):
     def setUp(self):
         self._original_rate = AuthRateThrottle.rate
+        self.addCleanup(setattr, AuthRateThrottle, "rate", self._original_rate)
         AuthRateThrottle.rate = None
         self.template_model = Template
         self.member_url = reverse("test_api_member_view")
         self.manager_url = reverse("test_api_manager_view")
         self.owner_url = reverse("test_api_owner_view")
-
-    def tearDown(self):
-        AuthRateThrottle.rate = self._original_rate
 
     def test_operator_none(self):
         self._get_operator()


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Made the dedicated authentication throttle rate authoritative when it is disabled, preventing DRF from looking up an unrelated global `user` throttle rate. Added regression coverage for a missing and configured global `user` rate, restored rate changes made by integration tests, and documented the `None` behavior.

## Screenshot

N/A