### PR TITLE
[tests] Refactored Selenium test logic to use new helpers

### DIFF
--- a/tests/testapp/tests/test_selenium.py
+++ b/tests/testapp/tests/test_selenium.py
@@ -5,7 +5,6 @@ from django.urls import reverse
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
-from selenium.webdriver.support.ui import WebDriverWait
 from swapper import load_model
 
 from openwisp_utils.test_selenium_mixins import SeleniumTestMixin
@@ -31,10 +30,10 @@ class TestOrganizationAutocompleteField(
         self.web_driver.find_element(
             By.CSS_SELECTOR, "#select2-id_organization-container"
         ).click()
-        WebDriverWait(self.web_driver, 2).until(
+        self.wait_until(
             EC.invisibility_of_element_located(
                 (By.CSS_SELECTOR, ".select2-results__option.loading-results")
-            )
+            ),
         )
         options = self.web_driver.find_elements(
             By.CSS_SELECTOR, ".select2-results__option"


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [N/A] I have updated the documentation.

## Reference to Existing Issue

N/A. This small test-maintenance change does not require a related issue.

## Description of Changes

Refactors Selenium tests to use `wait_until()` and removes a redundant timeout override.

## Screenshot

N/A. This change affects test code only.