### PR TITLE
[docs] Moved architecture diagrams to developer documentation

### DIFF
--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -3,6 +3,23 @@ Developer Installation Instructions
 
 .. include:: ../partials/developer-docs.rst
 
+The following diagram illustrates the role of the Users module within the
+OpenWISP architecture.
+
+.. figure:: ../images/architecture-v2-openwisp-users.png
+    :target: ../../_images/architecture-v2-openwisp-users.png
+    :align: center
+    :alt: OpenWISP Architecture: Users module
+
+    **OpenWISP Architecture: highlighted users module**
+
+.. important::
+
+    For an enhanced viewing experience, open the image above in a new
+    browser tab.
+
+    Refer to :doc:`/general/architecture` for more information.
+
 .. contents:: **Table of contents**:
     :depth: 2
     :local:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,23 +15,6 @@ within a single OpenWISP instance and more.
 
 For a full introduction please refer to :doc:`user/intro`.
 
-The following diagram illustrates the role of the Users module within the
-OpenWISP architecture.
-
-.. figure:: images/architecture-v2-openwisp-users.png
-    :target: ../_images/architecture-v2-openwisp-users.png
-    :align: center
-    :alt: OpenWISP Architecture: Users module
-
-    **OpenWISP Architecture: highlighted users module**
-
-.. important::
-
-    For an enhanced viewing experience, open the image above in a new
-    browser tab.
-
-    Refer to :doc:`/general/architecture` for more information.
-
 .. toctree::
     :caption: Users Module Usage Docs
     :maxdepth: 1


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Moves the OpenWISP architecture callout from the module landing page to the first developer documentation page.

## Screenshot

N/A